### PR TITLE
Namespace all namespaces in libwebm with adhoc:: prefix

### DIFF
--- a/common/file_util.cc
+++ b/common/file_util.cc
@@ -19,7 +19,7 @@
 #include <ios>
 #include <string>
 
-namespace libwebm {
+namespace adhoc::libwebm {
 
 std::string GetTempFileName() {
 #if !defined _MSC_VER && !defined __MINGW32__
@@ -90,4 +90,4 @@ TempFileDeleter::~TempFileDeleter() {
   }
 }
 
-}  // namespace libwebm
+}  // namespace adhoc::libwebm

--- a/common/file_util.h
+++ b/common/file_util.h
@@ -14,7 +14,7 @@
 
 #include "mkvmuxer/mkvmuxertypes.h"  // LIBWEBM_DISALLOW_COPY_AND_ASSIGN()
 
-namespace libwebm {
+namespace adhoc::libwebm {
 
 // Returns a temporary file name.
 std::string GetTempFileName();
@@ -39,6 +39,6 @@ class TempFileDeleter {
   LIBWEBM_DISALLOW_COPY_AND_ASSIGN(TempFileDeleter);
 };
 
-}  // namespace libwebm
+}  // namespace adhoc::libwebm
 
 #endif  // LIBWEBM_COMMON_FILE_UTIL_H_

--- a/common/hdr_util.cc
+++ b/common/hdr_util.cc
@@ -13,24 +13,24 @@
 
 #include "mkvparser/mkvparser.h"
 
-namespace libwebm {
+namespace adhoc::libwebm {
 const int Vp9CodecFeatures::kValueNotPresent = INT_MAX;
 
-bool CopyPrimaryChromaticity(const mkvparser::PrimaryChromaticity& parser_pc,
+bool CopyPrimaryChromaticity(const adhoc::mkvparser::PrimaryChromaticity& parser_pc,
                              PrimaryChromaticityPtr* muxer_pc) {
   muxer_pc->reset(new (std::nothrow)
-                      mkvmuxer::PrimaryChromaticity(parser_pc.x, parser_pc.y));
+                      adhoc::mkvmuxer::PrimaryChromaticity(parser_pc.x, parser_pc.y));
   if (!muxer_pc->get())
     return false;
   return true;
 }
 
 bool MasteringMetadataValuePresent(double value) {
-  return value != mkvparser::MasteringMetadata::kValueNotPresent;
+  return value != adhoc::mkvparser::MasteringMetadata::kValueNotPresent;
 }
 
-bool CopyMasteringMetadata(const mkvparser::MasteringMetadata& parser_mm,
-                           mkvmuxer::MasteringMetadata* muxer_mm) {
+bool CopyMasteringMetadata(const adhoc::mkvparser::MasteringMetadata& parser_mm,
+                           adhoc::mkvmuxer::MasteringMetadata* muxer_mm) {
   if (MasteringMetadataValuePresent(parser_mm.luminance_max))
     muxer_mm->set_luminance_max(parser_mm.luminance_max);
   if (MasteringMetadataValuePresent(parser_mm.luminance_min))
@@ -67,11 +67,11 @@ bool CopyMasteringMetadata(const mkvparser::MasteringMetadata& parser_mm,
 }
 
 bool ColourValuePresent(long long value) {
-  return value != mkvparser::Colour::kValueNotPresent;
+  return value != adhoc::mkvparser::Colour::kValueNotPresent;
 }
 
-bool CopyColour(const mkvparser::Colour& parser_colour,
-                mkvmuxer::Colour* muxer_colour) {
+bool CopyColour(const adhoc::mkvparser::Colour& parser_colour,
+                adhoc::mkvmuxer::Colour* muxer_colour) {
   if (!muxer_colour)
     return false;
 
@@ -109,7 +109,7 @@ bool CopyColour(const mkvparser::Colour& parser_colour,
     muxer_colour->set_max_fall(parser_colour.max_fall);
 
   if (parser_colour.mastering_metadata) {
-    mkvmuxer::MasteringMetadata muxer_mm;
+    adhoc::mkvmuxer::MasteringMetadata muxer_mm;
     if (!CopyMasteringMetadata(*parser_colour.mastering_metadata, &muxer_mm))
       return false;
     if (!muxer_colour->SetMasteringMetadata(muxer_mm))
@@ -217,4 +217,4 @@ bool ParseVpxCodecPrivate(const uint8_t* private_data, int32_t length,
 
   return true;
 }
-}  // namespace libwebm
+}  // namespace adhoc::libwebm

--- a/common/hdr_util.h
+++ b/common/hdr_util.h
@@ -14,13 +14,13 @@
 
 #include "mkvmuxer/mkvmuxer.h"
 
-namespace mkvparser {
+namespace adhoc::mkvparser {
 struct Colour;
 struct MasteringMetadata;
 struct PrimaryChromaticity;
-}  // namespace mkvparser
+}  // namespace adhoc::mkvparser
 
-namespace libwebm {
+namespace adhoc::libwebm {
 // Utility types and functions for working with the Colour element and its
 // children. Copiers return true upon success. Presence functions return true
 // when the specified element is present.
@@ -47,20 +47,20 @@ struct Vp9CodecFeatures {
   int chroma_subsampling;
 };
 
-typedef std::unique_ptr<mkvmuxer::PrimaryChromaticity> PrimaryChromaticityPtr;
+typedef std::unique_ptr<adhoc::mkvmuxer::PrimaryChromaticity> PrimaryChromaticityPtr;
 
-bool CopyPrimaryChromaticity(const mkvparser::PrimaryChromaticity& parser_pc,
+bool CopyPrimaryChromaticity(const adhoc::mkvparser::PrimaryChromaticity& parser_pc,
                              PrimaryChromaticityPtr* muxer_pc);
 
 bool MasteringMetadataValuePresent(double value);
 
-bool CopyMasteringMetadata(const mkvparser::MasteringMetadata& parser_mm,
-                           mkvmuxer::MasteringMetadata* muxer_mm);
+bool CopyMasteringMetadata(const adhoc::mkvparser::MasteringMetadata& parser_mm,
+                           adhoc::mkvmuxer::MasteringMetadata* muxer_mm);
 
 bool ColourValuePresent(long long value);
 
-bool CopyColour(const mkvparser::Colour& parser_colour,
-                mkvmuxer::Colour* muxer_colour);
+bool CopyColour(const adhoc::mkvparser::Colour& parser_colour,
+                adhoc::mkvmuxer::Colour* muxer_colour);
 
 // Returns true if |features| is set to one or more valid values.
 bool ParseVpxCodecPrivate(const uint8_t* private_data, int32_t length,

--- a/common/indent.cc
+++ b/common/indent.cc
@@ -12,7 +12,7 @@
 
 #include <string>
 
-namespace libwebm {
+namespace adhoc::libwebm {
 
 Indent::Indent(int indent) : indent_(indent), indent_str_() { Update(); }
 
@@ -26,4 +26,4 @@ void Indent::Adjust(int indent) {
 
 void Indent::Update() { indent_str_ = std::string(indent_, ' '); }
 
-}  // namespace libwebm
+}  // namespace adhoc::libwebm

--- a/common/indent.h
+++ b/common/indent.h
@@ -15,7 +15,7 @@
 
 #include "mkvmuxer/mkvmuxertypes.h"
 
-namespace libwebm {
+namespace adhoc::libwebm {
 
 const int kIncreaseIndent = 2;
 const int kDecreaseIndent = -2;
@@ -43,6 +43,6 @@ class Indent {
   LIBWEBM_DISALLOW_COPY_AND_ASSIGN(Indent);
 };
 
-}  // namespace libwebm
+}  // namespace adhoc::libwebm
 
 #endif  // LIBWEBM_COMMON_INDENT_H_

--- a/common/libwebm_util.cc
+++ b/common/libwebm_util.cc
@@ -12,7 +12,7 @@
 #include <cstdio>
 #include <limits>
 
-namespace libwebm {
+namespace adhoc::libwebm {
 
 std::int64_t NanosecondsTo90KhzTicks(std::int64_t nanoseconds) {
   const double pts_seconds = nanoseconds / kNanosecondsPerSecond;

--- a/common/libwebm_util.h
+++ b/common/libwebm_util.h
@@ -14,7 +14,7 @@
 #include <memory>
 #include <vector>
 
-namespace libwebm {
+namespace adhoc::libwebm {
 
 const double kNanosecondsPerSecond = 1000000000.0;
 
@@ -60,6 +60,6 @@ bool WriteUint8(std::uint8_t val, std::FILE* fileptr);
 // is a nullptr.
 std::uint16_t ReadUint16(const std::uint8_t* buf);
 
-}  // namespace libwebm
+}  // namespace adhoc::libwebm
 
 #endif  // LIBWEBM_COMMON_LIBWEBM_UTIL_H_

--- a/common/video_frame.cc
+++ b/common/video_frame.cc
@@ -9,7 +9,7 @@
 
 #include <cstdio>
 
-namespace libwebm {
+namespace adhoc::libwebm {
 
 bool VideoFrame::Buffer::Init(std::size_t new_length) {
   capacity = 0;

--- a/common/video_frame.h
+++ b/common/video_frame.h
@@ -11,7 +11,7 @@
 #include <cstdint>
 #include <memory>
 
-namespace libwebm {
+namespace adhoc::libwebm {
 
 // VideoFrame is a storage class for compressed video frames.
 class VideoFrame {
@@ -63,6 +63,5 @@ class VideoFrame {
   Codec codec_ = kVP9;
 };
 
-}  // namespace libwebm
-
+}  // namespace adhoc::libwebm
 #endif  // LIBWEBM_COMMON_VIDEO_FRAME_H_

--- a/common/vp9_header_parser.cc
+++ b/common/vp9_header_parser.cc
@@ -9,7 +9,7 @@
 
 #include <stdio.h>
 
-namespace vp9_parser {
+namespace adhoc::vp9_parser {
 
 bool Vp9HeaderParser::SetFrame(const uint8_t* frame, size_t length) {
   if (!frame || length == 0)

--- a/common/vp9_header_parser.h
+++ b/common/vp9_header_parser.h
@@ -11,7 +11,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-namespace vp9_parser {
+namespace adhoc::vp9_parser {
 
 const int kVp9FrameMarker = 2;
 const int kMinTileWidthB64 = 4;

--- a/common/vp9_header_parser_tests.cc
+++ b/common/vp9_header_parser_tests.cc
@@ -39,18 +39,18 @@ class Vp9HeaderParserTests : public ::testing::Test {
 
   void CreateAndLoadSegment(const std::string& filename,
                             int expected_doc_type_ver) {
-    filename_ = test::GetTestFilePath(filename);
+    filename_ = adhoc::test::GetTestFilePath(filename);
     ASSERT_EQ(0, reader_.Open(filename_.c_str()));
     is_reader_open_ = true;
     pos_ = 0;
-    mkvparser::EBMLHeader ebml_header;
+    adhoc::mkvparser::EBMLHeader ebml_header;
     ebml_header.Parse(&reader_, pos_);
     ASSERT_EQ(1, ebml_header.m_version);
     ASSERT_EQ(1, ebml_header.m_readVersion);
     ASSERT_STREQ("webm", ebml_header.m_docType);
     ASSERT_EQ(expected_doc_type_ver, ebml_header.m_docTypeVersion);
     ASSERT_EQ(2, ebml_header.m_docTypeReadVersion);
-    ASSERT_EQ(0, mkvparser::Segment::CreateInstance(&reader_, pos_, segment_));
+    ASSERT_EQ(0, adhoc::mkvparser::Segment::CreateInstance(&reader_, pos_, segment_));
     ASSERT_FALSE(HasFailure());
     ASSERT_GE(0, segment_->Load());
   }
@@ -61,44 +61,44 @@ class Vp9HeaderParserTests : public ::testing::Test {
 
   // Load a corrupted segment with no expectation of correctness.
   void CreateAndLoadInvalidSegment(const std::string& filename) {
-    filename_ = test::GetTestFilePath(filename);
+    filename_ = adhoc::test::GetTestFilePath(filename);
     ASSERT_EQ(0, reader_.Open(filename_.c_str()));
     is_reader_open_ = true;
     pos_ = 0;
-    mkvparser::EBMLHeader ebml_header;
+    adhoc::mkvparser::EBMLHeader ebml_header;
     ebml_header.Parse(&reader_, pos_);
-    ASSERT_EQ(0, mkvparser::Segment::CreateInstance(&reader_, pos_, segment_));
+    ASSERT_EQ(0, adhoc::mkvparser::Segment::CreateInstance(&reader_, pos_, segment_));
     ASSERT_GE(0, segment_->Load());
   }
 
   void ProcessTheFrames(bool invalid_bitstream) {
     unsigned char* data = NULL;
     size_t data_len = 0;
-    const mkvparser::Tracks* const parser_tracks = segment_->GetTracks();
+    const adhoc::mkvparser::Tracks* const parser_tracks = segment_->GetTracks();
     ASSERT_TRUE(parser_tracks != NULL);
-    const mkvparser::Cluster* cluster = segment_->GetFirst();
+    const adhoc::mkvparser::Cluster* cluster = segment_->GetFirst();
     ASSERT_TRUE(cluster != NULL);
 
     while ((cluster != NULL) && !cluster->EOS()) {
-      const mkvparser::BlockEntry* block_entry;
+      const adhoc::mkvparser::BlockEntry* block_entry;
       long status = cluster->GetFirst(block_entry);  // NOLINT
       ASSERT_EQ(0, status);
 
       while ((block_entry != NULL) && !block_entry->EOS()) {
-        const mkvparser::Block* const block = block_entry->GetBlock();
+        const adhoc::mkvparser::Block* const block = block_entry->GetBlock();
         ASSERT_TRUE(block != NULL);
         const long long trackNum = block->GetTrackNumber();  // NOLINT
-        const mkvparser::Track* const parser_track =
+        const adhoc::mkvparser::Track* const parser_track =
             parser_tracks->GetTrackByNumber(
                 static_cast<unsigned long>(trackNum));  // NOLINT
         ASSERT_TRUE(parser_track != NULL);
         const long long track_type = parser_track->GetType();  // NOLINT
 
-        if (track_type == mkvparser::Track::kVideo) {
+        if (track_type == adhoc::mkvparser::Track::kVideo) {
           const int frame_count = block->GetFrameCount();
 
           for (int i = 0; i < frame_count; ++i) {
-            const mkvparser::Block::Frame& frame = block->GetFrame(i);
+            const adhoc::mkvparser::Block::Frame& frame = block->GetFrame(i);
 
             if (static_cast<size_t>(frame.len) > data_len) {
               delete[] data;
@@ -122,12 +122,12 @@ class Vp9HeaderParserTests : public ::testing::Test {
   }
 
  protected:
-  mkvparser::MkvReader reader_;
+  adhoc::mkvparser::MkvReader reader_;
   bool is_reader_open_;
-  mkvparser::Segment* segment_;
+  adhoc::mkvparser::Segment* segment_;
   std::string filename_;
   long long pos_;  // NOLINT
-  vp9_parser::Vp9HeaderParser parser_;
+  adhoc::vp9_parser::Vp9HeaderParser parser_;
 };
 
 TEST_F(Vp9HeaderParserTests, VideoOnlyFile) {
@@ -166,7 +166,7 @@ TEST_F(Vp9HeaderParserTests, Invalid) {
 }
 
 TEST_F(Vp9HeaderParserTests, API) {
-  vp9_parser::Vp9HeaderParser parser;
+  adhoc::vp9_parser::Vp9HeaderParser parser;
   uint8_t data;
   EXPECT_FALSE(parser.ParseUncompressedHeader(NULL, 0));
   EXPECT_FALSE(parser.ParseUncompressedHeader(NULL, 10));

--- a/common/vp9_level_stats.cc
+++ b/common/vp9_level_stats.cc
@@ -14,7 +14,7 @@
 
 #include "common/webm_constants.h"
 
-namespace vp9_parser {
+namespace adhoc::vp9_parser {
 
 const Vp9LevelRow Vp9LevelStats::Vp9LevelTable[kNumVp9Levels] = {
     {LEVEL_1, 829440, 36864, 512, 200, 400, 2, 1, 4, 8},
@@ -52,7 +52,7 @@ void Vp9LevelStats::AddFrame(const Vp9HeaderParser& parser, int64_t time_ns) {
 
   while (!luma_window_.empty() &&
          luma_window_.front().first <
-             (time_ns - (libwebm::kNanosecondsPerSecondi - 1))) {
+             (time_ns - (adhoc::libwebm::kNanosecondsPerSecondi - 1))) {
     current_luma_size_ -= luma_window_.front().second;
     luma_window_.pop();
   }
@@ -234,11 +234,11 @@ double Vp9LevelStats::GetAverageBitRate() const {
   const int64_t frame_duration_ns = end_ns_ - start_ns_;
   double duration_seconds =
       ((duration_ns_ == -1) ? frame_duration_ns : duration_ns_) /
-      libwebm::kNanosecondsPerSecond;
+      adhoc::libwebm::kNanosecondsPerSecond;
   if (estimate_last_frame_duration_ &&
       (duration_ns_ == -1 || duration_ns_ <= frame_duration_ns)) {
     const double sec_per_frame = frame_duration_ns /
-                                 libwebm::kNanosecondsPerSecond /
+                                 adhoc::libwebm::kNanosecondsPerSecond /
                                  (displayed_frames - 1);
     duration_seconds += sec_per_frame;
   }

--- a/common/vp9_level_stats.h
+++ b/common/vp9_level_stats.h
@@ -14,7 +14,7 @@
 
 #include "common/vp9_header_parser.h"
 
-namespace vp9_parser {
+namespace adhoc::vp9_parser {
 
 const int kMaxVp9RefFrames = 8;
 

--- a/common/vp9_level_stats_tests.cc
+++ b/common/vp9_level_stats_tests.cc
@@ -38,19 +38,19 @@ class Vp9LevelStatsTests : public ::testing::Test {
   void CreateAndLoadSegment(const std::string& filename,
                             int expected_doc_type_ver) {
     ASSERT_NE(0u, filename.length());
-    filename_ = test::GetTestFilePath(filename);
+    filename_ = adhoc::test::GetTestFilePath(filename);
     ASSERT_EQ(0, reader_.Open(filename_.c_str()));
     is_reader_open_ = true;
     pos_ = 0;
-    mkvparser::EBMLHeader ebml_header;
+    adhoc::mkvparser::EBMLHeader ebml_header;
     ebml_header.Parse(&reader_, pos_);
     ASSERT_EQ(1, ebml_header.m_version);
     ASSERT_EQ(1, ebml_header.m_readVersion);
     ASSERT_STREQ("webm", ebml_header.m_docType);
     ASSERT_EQ(expected_doc_type_ver, ebml_header.m_docTypeVersion);
     ASSERT_EQ(2, ebml_header.m_docTypeReadVersion);
-    mkvparser::Segment* temp;
-    ASSERT_EQ(0, mkvparser::Segment::CreateInstance(&reader_, pos_, temp));
+    adhoc::mkvparser::Segment* temp;
+    ASSERT_EQ(0, adhoc::mkvparser::Segment::CreateInstance(&reader_, pos_, temp));
     segment_.reset(temp);
     ASSERT_FALSE(HasFailure());
     ASSERT_GE(0, segment_->Load());
@@ -63,32 +63,32 @@ class Vp9LevelStatsTests : public ::testing::Test {
   void ProcessTheFrames() {
     std::vector<uint8_t> data;
     size_t data_len = 0;
-    const mkvparser::Tracks* const parser_tracks = segment_->GetTracks();
+    const adhoc::mkvparser::Tracks* const parser_tracks = segment_->GetTracks();
     ASSERT_TRUE(parser_tracks != NULL);
-    const mkvparser::Cluster* cluster = segment_->GetFirst();
+    const adhoc::mkvparser::Cluster* cluster = segment_->GetFirst();
     ASSERT_TRUE(cluster);
 
     while ((cluster != NULL) && !cluster->EOS()) {
-      const mkvparser::BlockEntry* block_entry;
+      const adhoc::mkvparser::BlockEntry* block_entry;
       long status = cluster->GetFirst(block_entry);  // NOLINT
       ASSERT_EQ(0, status);
 
       while ((block_entry != NULL) && !block_entry->EOS()) {
-        const mkvparser::Block* const block = block_entry->GetBlock();
+        const adhoc::mkvparser::Block* const block = block_entry->GetBlock();
         ASSERT_TRUE(block != NULL);
         const long long trackNum = block->GetTrackNumber();  // NOLINT
-        const mkvparser::Track* const parser_track =
+        const adhoc::mkvparser::Track* const parser_track =
             parser_tracks->GetTrackByNumber(
                 static_cast<unsigned long>(trackNum));  // NOLINT
         ASSERT_TRUE(parser_track != NULL);
         const long long track_type = parser_track->GetType();  // NOLINT
 
-        if (track_type == mkvparser::Track::kVideo) {
+        if (track_type == adhoc::mkvparser::Track::kVideo) {
           const int frame_count = block->GetFrameCount();
           const long long time_ns = block->GetTime(cluster);  // NOLINT
 
           for (int i = 0; i < frame_count; ++i) {
-            const mkvparser::Block::Frame& frame = block->GetFrame(i);
+            const adhoc::mkvparser::Block::Frame& frame = block->GetFrame(i);
             if (static_cast<size_t>(frame.len) > data.size()) {
               data.resize(frame.len);
               data_len = static_cast<size_t>(frame.len);
@@ -108,13 +108,13 @@ class Vp9LevelStatsTests : public ::testing::Test {
   }
 
  protected:
-  mkvparser::MkvReader reader_;
+  adhoc::mkvparser::MkvReader reader_;
   bool is_reader_open_;
-  std::unique_ptr<mkvparser::Segment> segment_;
+  std::unique_ptr<adhoc::mkvparser::Segment> segment_;
   std::string filename_;
   long long pos_;  // NOLINT
-  vp9_parser::Vp9HeaderParser parser_;
-  vp9_parser::Vp9LevelStats stats_;
+  adhoc::vp9_parser::Vp9HeaderParser parser_;
+  adhoc::vp9_parser::Vp9LevelStats stats_;
 };
 
 TEST_F(Vp9LevelStatsTests, VideoOnlyFile) {

--- a/common/webm_constants.h
+++ b/common/webm_constants.h
@@ -9,12 +9,11 @@
 #ifndef LIBWEBM_COMMON_WEBM_CONSTANTS_H_
 #define LIBWEBM_COMMON_WEBM_CONSTANTS_H_
 
-namespace libwebm {
+namespace adhoc::libwebm {
 
 const double kNanosecondsPerSecond = 1000000000.0;
 const int kNanosecondsPerSecondi = 1000000000;
 const int kNanosecondsPerMillisecond = 1000000;
 
-}  // namespace libwebm
-
+}  // namespace adhoc::libwebm
 #endif  // LIBWEBM_COMMON_WEBM_CONSTANTS_H_

--- a/common/webm_endian.cc
+++ b/common/webm_endian.cc
@@ -64,7 +64,7 @@ uint64_t swap64_check_little_endian(uint64_t value) {
 
 }  // namespace
 
-namespace libwebm {
+namespace adhoc::libwebm {
 
 uint32_t host_to_bigendian(uint32_t value) {
   return swap32_check_little_endian(value);
@@ -82,4 +82,4 @@ uint64_t bigendian_to_host(uint64_t value) {
   return swap64_check_little_endian(value);
 }
 
-}  // namespace libwebm
+}  // namespace adhoc::libwebm

--- a/common/webm_endian.h
+++ b/common/webm_endian.h
@@ -11,7 +11,7 @@
 
 #include <stdint.h>
 
-namespace libwebm {
+namespace adhoc::libwebm {
 
 // Swaps unsigned 32 bit values to big endian if needed. Returns |value| if
 // architecture is big endian. Returns big endian value if architecture is
@@ -33,6 +33,5 @@ uint64_t host_to_bigendian(uint64_t value);
 // little endian. Returns 0 otherwise.
 uint64_t bigendian_to_host(uint64_t value);
 
-}  // namespace libwebm
-
+}  // namespace adhoc::libwebm
 #endif  // LIBWEBM_COMMON_WEBM_ENDIAN_H_

--- a/common/webmids.h
+++ b/common/webmids.h
@@ -9,7 +9,7 @@
 #ifndef COMMON_WEBMIDS_H_
 #define COMMON_WEBMIDS_H_
 
-namespace libwebm {
+namespace adhoc::libwebm {
 
 enum MkvId {
   kMkvEBML = 0x1A45DFA3,
@@ -188,6 +188,5 @@ enum MkvId {
   kMkvTagString = 0x4487
 };
 
-}  // namespace libwebm
-
+}  // namespace adhoc::libwebm
 #endif  // COMMON_WEBMIDS_H_

--- a/dumpvtt.cc
+++ b/dumpvtt.cc
@@ -17,7 +17,7 @@ int main(int argc, const char* argv[]) {
     return EXIT_SUCCESS;
   }
 
-  libwebvtt::VttReader reader;
+  adhoc::libwebvtt::VttReader reader;
   const char* const filename = argv[1];
 
   if (int e = reader.Open(filename)) {
@@ -26,7 +26,7 @@ int main(int argc, const char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  libwebvtt::Parser parser(&reader);
+  adhoc::libwebvtt::Parser parser(&reader);
 
   if (int e = parser.Init()) {
     (void)e;
@@ -34,7 +34,7 @@ int main(int argc, const char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  for (libwebvtt::Cue cue;;) {
+  for (adhoc::libwebvtt::Cue cue;;) {
     const int e = parser.Parse(&cue);
 
     if (e < 0) {  // error
@@ -47,16 +47,16 @@ int main(int argc, const char* argv[]) {
 
     fprintf(stdout, "cue identifier: \"%s\"\n", cue.identifier.c_str());
 
-    const libwebvtt::Time& st = cue.start_time;
+    const adhoc::libwebvtt::Time& st = cue.start_time;
     fprintf(stdout, "cue start time: \"HH=%i MM=%i SS=%i SSS=%i\"\n", st.hours,
             st.minutes, st.seconds, st.milliseconds);
 
-    const libwebvtt::Time& sp = cue.stop_time;
+    const adhoc::libwebvtt::Time& sp = cue.stop_time;
     fprintf(stdout, "cue stop time: \"HH=%i MM=%i SS=%i SSS=%i\"\n", sp.hours,
             sp.minutes, sp.seconds, sp.milliseconds);
 
     {
-      typedef libwebvtt::Cue::settings_t::const_iterator iter_t;
+      typedef adhoc::libwebvtt::Cue::settings_t::const_iterator iter_t;
       iter_t i = cue.settings.begin();
       const iter_t j = cue.settings.end();
 
@@ -64,7 +64,7 @@ int main(int argc, const char* argv[]) {
         fprintf(stdout, "cue setting: <no settings present>\n");
       } else {
         while (i != j) {
-          const libwebvtt::Setting& setting = *i++;
+          const adhoc::libwebvtt::Setting& setting = *i++;
           fprintf(stdout, "cue setting: name=%s value=%s\n",
                   setting.name.c_str(), setting.value.c_str());
         }
@@ -72,7 +72,7 @@ int main(int argc, const char* argv[]) {
     }
 
     {
-      typedef libwebvtt::Cue::payload_t::const_iterator iter_t;
+      typedef adhoc::libwebvtt::Cue::payload_t::const_iterator iter_t;
       iter_t i = cue.payload.begin();
       const iter_t j = cue.payload.end();
 

--- a/m2ts/tests/webm2pes_tests.cc
+++ b/m2ts/tests/webm2pes_tests.cc
@@ -40,12 +40,12 @@ class Webm2PesTests : public ::testing::Test {
   ~Webm2PesTests() = default;
 
   void CreateAndLoadTestInput() {
-    libwebm::Webm2Pes converter(input_file_name_, temp_file_name_.name());
+    adhoc::libwebm::Webm2Pes converter(input_file_name_, temp_file_name_.name());
     ASSERT_TRUE(converter.ConvertToFile());
     ASSERT_TRUE(parser_.Open(pes_file_name()));
   }
 
-  bool VerifyPacketStartCode(const libwebm::VpxPesParser::PesHeader& header) {
+  bool VerifyPacketStartCode(const adhoc::libwebm::VpxPesParser::PesHeader& header) {
     // PES packets all start with the byte sequence 0x0 0x0 0x1.
     if (header.start_code[0] != 0 || header.start_code[1] != 0 ||
         header.start_code[2] != 1) {
@@ -55,21 +55,21 @@ class Webm2PesTests : public ::testing::Test {
   }
 
   const std::string& pes_file_name() const { return temp_file_name_.name(); }
-  libwebm::VpxPesParser* parser() { return &parser_; }
+  adhoc::libwebm::VpxPesParser* parser() { return &parser_; }
 
  private:
-  const libwebm::TempFileDeleter temp_file_name_;
+  const adhoc::libwebm::TempFileDeleter temp_file_name_;
   const std::string input_file_name_ =
-      test::GetTestFilePath("bbb_480p_vp9_opus_1second.webm");
-  libwebm::VpxPesParser parser_;
+      adhoc::test::GetTestFilePath("bbb_480p_vp9_opus_1second.webm");
+  adhoc::libwebm::VpxPesParser parser_;
 };
 
 TEST_F(Webm2PesTests, CreatePesFile) { CreateAndLoadTestInput(); }
 
 TEST_F(Webm2PesTests, CanParseFirstPacket) {
   CreateAndLoadTestInput();
-  libwebm::VpxPesParser::PesHeader header;
-  libwebm::VideoFrame frame;
+  adhoc::libwebm::VpxPesParser::PesHeader header;
+  adhoc::libwebm::VideoFrame frame;
   ASSERT_TRUE(parser()->ParseNextPacket(&header, &frame));
   EXPECT_TRUE(VerifyPacketStartCode(header));
 
@@ -99,7 +99,7 @@ TEST_F(Webm2PesTests, CanParseFirstPacket) {
   // Note: The length field of the BCMV header includes its own length.
   const std::size_t kBcmvBaseLength = 10;
   const std::size_t kFirstFrameLength = 83;
-  const libwebm::VpxPesParser::BcmvHeader kFirstBcmvHeader(kFirstFrameLength +
+  const adhoc::libwebm::VpxPesParser::BcmvHeader kFirstBcmvHeader(kFirstFrameLength +
                                                            kBcmvBaseLength);
   EXPECT_TRUE(header.bcmv_header.Valid());
   EXPECT_EQ(kFirstBcmvHeader, header.bcmv_header);
@@ -110,29 +110,29 @@ TEST_F(Webm2PesTests, CanParseFirstPacket) {
 
 TEST_F(Webm2PesTests, CanMuxLargeBuffers) {
   const std::size_t kBufferSize = 100 * 1024;
-  const std::int64_t kFakeTimestamp = libwebm::kNanosecondsPerSecond;
-  libwebm::VideoFrame fake_frame(kFakeTimestamp, libwebm::VideoFrame::kVP9);
+  const std::int64_t kFakeTimestamp = adhoc::libwebm::kNanosecondsPerSecond;
+  adhoc::libwebm::VideoFrame fake_frame(kFakeTimestamp, adhoc::libwebm::VideoFrame::kVP9);
   ASSERT_TRUE(fake_frame.Init(kBufferSize));
   std::memset(fake_frame.buffer().data.get(), 0x80, kBufferSize);
   ASSERT_TRUE(fake_frame.SetBufferLength(kBufferSize));
-  libwebm::PacketDataBuffer pes_packet_buffer;
+  adhoc::libwebm::PacketDataBuffer pes_packet_buffer;
   ASSERT_TRUE(
-      libwebm::Webm2Pes::WritePesPacket(fake_frame, &pes_packet_buffer));
+      adhoc::libwebm::Webm2Pes::WritePesPacket(fake_frame, &pes_packet_buffer));
 
   // TODO(tomfinegan): Change VpxPesParser so it can read from a buffer, and get
   // rid of this extra step.
-  libwebm::FilePtr pes_file(std::fopen(pes_file_name().c_str(), "wb"),
-                            libwebm::FILEDeleter());
+  adhoc::libwebm::FilePtr pes_file(std::fopen(pes_file_name().c_str(), "wb"),
+                            adhoc::libwebm::FILEDeleter());
   ASSERT_EQ(pes_packet_buffer.size(),
             fwrite(&pes_packet_buffer[0], 1, pes_packet_buffer.size(),
                    pes_file.get()));
   fclose(pes_file.get());
   pes_file.release();
 
-  libwebm::VpxPesParser parser;
+  adhoc::libwebm::VpxPesParser parser;
   ASSERT_TRUE(parser.Open(pes_file_name()));
-  libwebm::VpxPesParser::PesHeader header;
-  libwebm::VideoFrame parsed_frame;
+  adhoc::libwebm::VpxPesParser::PesHeader header;
+  adhoc::libwebm::VideoFrame parsed_frame;
   ASSERT_TRUE(parser.ParseNextPacket(&header, &parsed_frame));
   EXPECT_EQ(fake_frame.nanosecond_pts(), parsed_frame.nanosecond_pts());
   EXPECT_EQ(fake_frame.buffer().length, parsed_frame.buffer().length);
@@ -142,8 +142,8 @@ TEST_F(Webm2PesTests, CanMuxLargeBuffers) {
 
 TEST_F(Webm2PesTests, ParserConsumesAllInput) {
   CreateAndLoadTestInput();
-  libwebm::VpxPesParser::PesHeader header;
-  libwebm::VideoFrame frame;
+  adhoc::libwebm::VpxPesParser::PesHeader header;
+  adhoc::libwebm::VideoFrame frame;
   while (parser()->ParseNextPacket(&header, &frame) == true) {
     EXPECT_TRUE(VerifyPacketStartCode(header));
   }

--- a/m2ts/vpxpes2ts.cc
+++ b/m2ts/vpxpes2ts.cc
@@ -12,7 +12,7 @@
 #include <cstdio>
 #include <vector>
 
-namespace libwebm {
+namespace adhoc::libwebm {
 // TODO(tomfinegan): Dedupe this and PesHeaderField.
 // Stores a value and its size in bits for writing into a MPEG2 TS Header.
 // Maximum size is 64 bits. Users may call the Check() method to perform minimal
@@ -214,4 +214,4 @@ bool VpxPes2Ts::ReceivePacket(const PacketDataBuffer& packet_data) {
   return true;
 }
 
-}  // namespace libwebm
+}  // namespace adhoc::libwebm

--- a/m2ts/vpxpes2ts.h
+++ b/m2ts/vpxpes2ts.h
@@ -14,7 +14,7 @@
 #include "common/libwebm_util.h"
 #include "m2ts/webm2pes.h"
 
-namespace libwebm {
+namespace adhoc::libwebm {
 
 class VpxPes2Ts : public PacketReceiverInterface {
  public:
@@ -40,6 +40,5 @@ class VpxPes2Ts : public PacketReceiverInterface {
   PacketDataBuffer ts_buffer_;
 };
 
-}  // namespace libwebm
-
+}  // namespace adhoc::libwebm
 #endif  // LIBWEBM_M2TS_VPXPES2TS_H_

--- a/m2ts/vpxpes2ts_main.cc
+++ b/m2ts/vpxpes2ts_main.cc
@@ -28,6 +28,6 @@ int main(int argc, const char* argv[]) {
   const std::string input_path = argv[1];
   const std::string output_path = argv[2];
 
-  libwebm::VpxPes2Ts converter(input_path, output_path);
+  adhoc::libwebm::VpxPes2Ts converter(input_path, output_path);
   return converter.ConvertToFile() == true ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/m2ts/vpxpes_parser.cc
+++ b/m2ts/vpxpes_parser.cc
@@ -15,7 +15,7 @@
 
 #include "common/file_util.h"
 
-namespace libwebm {
+namespace adhoc::libwebm {
 
 VpxPesParser::BcmvHeader::BcmvHeader(std::uint32_t len) : length(len) {
   id[0] = 'B';
@@ -38,12 +38,12 @@ bool VpxPesParser::BcmvHeader::Valid() const {
 // file, and one that reads one packet at a time. As things are files larger
 // than the maximum availble memory for the current process cannot be loaded.
 bool VpxPesParser::Open(const std::string& pes_file) {
-  pes_file_size_ = static_cast<size_t>(libwebm::GetFileSize(pes_file));
+  pes_file_size_ = static_cast<size_t>(adhoc::libwebm::GetFileSize(pes_file));
   if (pes_file_size_ <= 0)
     return false;
   pes_file_data_.reserve(static_cast<size_t>(pes_file_size_));
-  libwebm::FilePtr file = libwebm::FilePtr(std::fopen(pes_file.c_str(), "rb"),
-                                           libwebm::FILEDeleter());
+  adhoc::libwebm::FilePtr file = adhoc::libwebm::FilePtr(std::fopen(pes_file.c_str(), "rb"),
+                                           adhoc::libwebm::FILEDeleter());
   int byte;
   while ((byte = fgetc(file.get())) != EOF) {
     pes_file_data_.push_back(static_cast<std::uint8_t>(byte));
@@ -406,4 +406,4 @@ bool VpxPesParser::ParseNextPacket(PesHeader* header, VideoFrame* frame) {
   return true;
 }
 
-}  // namespace libwebm
+}  // namespace adhoc::libwebm

--- a/m2ts/vpxpes_parser.h
+++ b/m2ts/vpxpes_parser.h
@@ -15,7 +15,7 @@
 #include "common/libwebm_util.h"
 #include "common/video_frame.h"
 
-namespace libwebm {
+namespace adhoc::libwebm {
 
 // Parser for VPx PES. Requires that the _entire_ PES stream can be stored in
 // a std::vector<std::uint8_t> and read into memory when Open() is called.
@@ -172,6 +172,5 @@ class VpxPesParser {
   ParseState parse_state_ = kFindStartCode;
 };
 
-}  // namespace libwebm
-
+}  // namespace adhoc::libwebm
 #endif  // LIBWEBM_M2TS_VPXPES_PARSER_H_

--- a/m2ts/webm2pes.cc
+++ b/m2ts/webm2pes.cc
@@ -16,7 +16,7 @@
 
 #include "common/libwebm_util.h"
 
-namespace libwebm {
+namespace adhoc::libwebm {
 
 const std::size_t Webm2Pes::kMaxPayloadSize = 32768;
 
@@ -229,9 +229,9 @@ bool Webm2Pes::ConvertToFile() {
   }
 
   // Walk clusters in segment.
-  const mkvparser::Cluster* cluster = webm_parser_->GetFirst();
+  const adhoc::mkvparser::Cluster* cluster = webm_parser_->GetFirst();
   while (cluster != nullptr && cluster->EOS() == false) {
-    const mkvparser::BlockEntry* block_entry = nullptr;
+    const adhoc::mkvparser::BlockEntry* block_entry = nullptr;
     std::int64_t block_status = cluster->GetFirst(block_entry);
     if (block_status < 0) {
       std::fprintf(stderr, "Webm2Pes: Cannot parse first block in %s.\n",
@@ -241,13 +241,13 @@ bool Webm2Pes::ConvertToFile() {
 
     // Walk blocks in cluster.
     while (block_entry != nullptr && block_entry->EOS() == false) {
-      const mkvparser::Block* block = block_entry->GetBlock();
+      const adhoc::mkvparser::Block* block = block_entry->GetBlock();
       if (block->GetTrackNumber() == video_track_num_) {
         const int frame_count = block->GetFrameCount();
 
         // Walk frames in block.
         for (int frame_num = 0; frame_num < frame_count; ++frame_num) {
-          const mkvparser::Block::Frame& mkvparser_frame =
+          const adhoc::mkvparser::Block::Frame& mkvparser_frame =
               block->GetFrame(frame_num);
 
           // Read the frame.
@@ -299,9 +299,9 @@ bool Webm2Pes::ConvertToPacketReceiver() {
   }
 
   // Walk clusters in segment.
-  const mkvparser::Cluster* cluster = webm_parser_->GetFirst();
+  const adhoc::mkvparser::Cluster* cluster = webm_parser_->GetFirst();
   while (cluster != nullptr && cluster->EOS() == false) {
-    const mkvparser::BlockEntry* block_entry = nullptr;
+    const adhoc::mkvparser::BlockEntry* block_entry = nullptr;
     std::int64_t block_status = cluster->GetFirst(block_entry);
     if (block_status < 0) {
       std::fprintf(stderr, "Webm2Pes: Cannot parse first block in %s.\n",
@@ -311,13 +311,13 @@ bool Webm2Pes::ConvertToPacketReceiver() {
 
     // Walk blocks in cluster.
     while (block_entry != nullptr && block_entry->EOS() == false) {
-      const mkvparser::Block* block = block_entry->GetBlock();
+      const adhoc::mkvparser::Block* block = block_entry->GetBlock();
       if (block->GetTrackNumber() == video_track_num_) {
         const int frame_count = block->GetFrameCount();
 
         // Walk frames in block.
         for (int frame_num = 0; frame_num < frame_count; ++frame_num) {
-          const mkvparser::Block::Frame& mkvparser_frame =
+          const adhoc::mkvparser::Block::Frame& mkvparser_frame =
               block->GetFrame(frame_num);
 
           // Read the frame.
@@ -360,7 +360,7 @@ bool Webm2Pes::InitWebmParser() {
     return false;
   }
 
-  using mkvparser::Segment;
+  using adhoc::mkvparser::Segment;
   Segment* webm_parser = nullptr;
   if (Segment::CreateInstance(&webm_reader_, 0 /* pos */,
                               webm_parser /* Segment*& */) != 0) {
@@ -376,7 +376,7 @@ bool Webm2Pes::InitWebmParser() {
   }
 
   // Make sure there's a video track.
-  const mkvparser::Tracks* tracks = webm_parser_->GetTracks();
+  const adhoc::mkvparser::Tracks* tracks = webm_parser_->GetTracks();
   if (tracks == nullptr) {
     std::fprintf(stderr, "Webm2Pes: %s has no tracks.\n",
                  input_file_name_.c_str());
@@ -388,8 +388,8 @@ bool Webm2Pes::InitWebmParser() {
   for (int track_index = 0;
        track_index < static_cast<int>(tracks->GetTracksCount());
        ++track_index) {
-    const mkvparser::Track* track = tracks->GetTrackByIndex(track_index);
-    if (track && track->GetType() == mkvparser::Track::kVideo) {
+    const adhoc::mkvparser::Track* track = tracks->GetTrackByIndex(track_index);
+    if (track && track->GetType() == adhoc::mkvparser::Track::kVideo) {
       const std::string codec_id = ToString(track->GetCodecId());
       if (codec_id == std::string("V_VP8")) {
         codec_ = VideoFrame::kVP8;
@@ -411,7 +411,7 @@ bool Webm2Pes::InitWebmParser() {
   return true;
 }
 
-bool Webm2Pes::ReadVideoFrame(const mkvparser::Block::Frame& mkvparser_frame,
+bool Webm2Pes::ReadVideoFrame(const adhoc::mkvparser::Block::Frame& mkvparser_frame,
                               VideoFrame* frame) {
   if (mkvparser_frame.len < 1 || frame == nullptr)
     return false;
@@ -548,4 +548,4 @@ bool CopyAndEscapeStartCodes(const std::uint8_t* raw_input,
   return true;
 }
 
-}  // namespace libwebm
+}  // namespace adhoc::libwebm

--- a/m2ts/webm2pes.h
+++ b/m2ts/webm2pes.h
@@ -43,7 +43,7 @@
 // emulation prevention bytes must be stripped from the output stream before
 // it can be parsed.
 
-namespace libwebm {
+namespace adhoc::libwebm {
 
 // Stores a value and its size in bits for writing into a PES Optional Header.
 // Maximum size is 64 bits. Users may call the Check() method to perform minimal
@@ -228,13 +228,13 @@ class Webm2Pes {
 
  private:
   bool InitWebmParser();
-  bool ReadVideoFrame(const mkvparser::Block::Frame& mkvparser_frame,
+  bool ReadVideoFrame(const adhoc::mkvparser::Block::Frame& mkvparser_frame,
                       VideoFrame* frame);
 
   const std::string input_file_name_;
   const std::string output_file_name_;
-  std::unique_ptr<mkvparser::Segment> webm_parser_;
-  mkvparser::MkvReader webm_reader_;
+  std::unique_ptr<adhoc::mkvparser::Segment> webm_parser_;
+  adhoc::mkvparser::MkvReader webm_reader_;
   FilePtr output_file_;
 
   // Video track num in the WebM file.
@@ -269,6 +269,5 @@ class Webm2Pes {
 bool CopyAndEscapeStartCodes(const std::uint8_t* raw_input,
                              std::size_t raw_input_length,
                              PacketDataBuffer* packet_buffer);
-}  // namespace libwebm
-
+}  // namespace adhoc::libwebm
 #endif  // LIBWEBM_M2TS_WEBM2PES_H_

--- a/m2ts/webm2pes_main.cc
+++ b/m2ts/webm2pes_main.cc
@@ -28,6 +28,6 @@ int main(int argc, const char* argv[]) {
   const std::string input_path = argv[1];
   const std::string output_path = argv[2];
 
-  libwebm::Webm2Pes converter(input_path, output_path);
+  adhoc::libwebm::Webm2Pes converter(input_path, output_path);
   return converter.ConvertToFile() == true ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/mkvmuxer/mkvmuxer.cc
+++ b/mkvmuxer/mkvmuxer.cc
@@ -26,7 +26,7 @@
 #include "mkvmuxer/mkvwriter.h"
 #include "mkvparser/mkvparser.h"
 
-namespace mkvmuxer {
+namespace adhoc::mkvmuxer {
 
 const float PrimaryChromaticity::kChromaticityMin = 0.0f;
 const float PrimaryChromaticity::kChromaticityMax = 1.0f;
@@ -97,42 +97,42 @@ bool WriteEbmlHeader(IMkvWriter* writer, uint64_t doc_type_version,
                      const char* const doc_type) {
   // Level 0
   uint64_t size =
-      EbmlElementSize(libwebm::kMkvEBMLVersion, static_cast<uint64>(1));
-  size += EbmlElementSize(libwebm::kMkvEBMLReadVersion, static_cast<uint64>(1));
-  size += EbmlElementSize(libwebm::kMkvEBMLMaxIDLength, static_cast<uint64>(4));
+      EbmlElementSize(adhoc::libwebm::kMkvEBMLVersion, static_cast<uint64>(1));
+  size += EbmlElementSize(adhoc::libwebm::kMkvEBMLReadVersion, static_cast<uint64>(1));
+  size += EbmlElementSize(adhoc::libwebm::kMkvEBMLMaxIDLength, static_cast<uint64>(4));
   size +=
-      EbmlElementSize(libwebm::kMkvEBMLMaxSizeLength, static_cast<uint64>(8));
-  size += EbmlElementSize(libwebm::kMkvDocType, doc_type);
-  size += EbmlElementSize(libwebm::kMkvDocTypeVersion,
+      EbmlElementSize(adhoc::libwebm::kMkvEBMLMaxSizeLength, static_cast<uint64>(8));
+  size += EbmlElementSize(adhoc::libwebm::kMkvDocType, doc_type);
+  size += EbmlElementSize(adhoc::libwebm::kMkvDocTypeVersion,
                           static_cast<uint64>(doc_type_version));
   size +=
-      EbmlElementSize(libwebm::kMkvDocTypeReadVersion, static_cast<uint64>(2));
+      EbmlElementSize(adhoc::libwebm::kMkvDocTypeReadVersion, static_cast<uint64>(2));
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvEBML, size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvEBML, size))
     return false;
-  if (!WriteEbmlElement(writer, libwebm::kMkvEBMLVersion,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvEBMLVersion,
                         static_cast<uint64>(1))) {
     return false;
   }
-  if (!WriteEbmlElement(writer, libwebm::kMkvEBMLReadVersion,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvEBMLReadVersion,
                         static_cast<uint64>(1))) {
     return false;
   }
-  if (!WriteEbmlElement(writer, libwebm::kMkvEBMLMaxIDLength,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvEBMLMaxIDLength,
                         static_cast<uint64>(4))) {
     return false;
   }
-  if (!WriteEbmlElement(writer, libwebm::kMkvEBMLMaxSizeLength,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvEBMLMaxSizeLength,
                         static_cast<uint64>(8))) {
     return false;
   }
-  if (!WriteEbmlElement(writer, libwebm::kMkvDocType, doc_type))
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvDocType, doc_type))
     return false;
-  if (!WriteEbmlElement(writer, libwebm::kMkvDocTypeVersion,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvDocTypeVersion,
                         static_cast<uint64>(doc_type_version))) {
     return false;
   }
-  if (!WriteEbmlElement(writer, libwebm::kMkvDocTypeReadVersion,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvDocTypeReadVersion,
                         static_cast<uint64>(2))) {
     return false;
   }
@@ -145,10 +145,10 @@ bool WriteEbmlHeader(IMkvWriter* writer, uint64_t doc_type_version) {
 }
 
 bool WriteEbmlHeader(IMkvWriter* writer) {
-  return WriteEbmlHeader(writer, mkvmuxer::Segment::kDefaultDocTypeVersion);
+  return WriteEbmlHeader(writer, adhoc::mkvmuxer::Segment::kDefaultDocTypeVersion);
 }
 
-bool ChunkedCopy(mkvparser::IMkvReader* source, mkvmuxer::IMkvWriter* dst,
+bool ChunkedCopy(adhoc::mkvparser::IMkvReader* source, adhoc::mkvmuxer::IMkvWriter* dst,
                  int64_t start, int64_t size) {
   // TODO(vigneshv): Check if this is a reasonable value.
   const uint32_t kBufSize = 2048;
@@ -296,42 +296,42 @@ bool CuePoint::Write(IMkvWriter* writer) const {
   if (!writer || track_ < 1 || cluster_pos_ < 1)
     return false;
 
-  uint64_t size = EbmlElementSize(libwebm::kMkvCueClusterPosition,
+  uint64_t size = EbmlElementSize(adhoc::libwebm::kMkvCueClusterPosition,
                                   static_cast<uint64>(cluster_pos_));
-  size += EbmlElementSize(libwebm::kMkvCueTrack, static_cast<uint64>(track_));
+  size += EbmlElementSize(adhoc::libwebm::kMkvCueTrack, static_cast<uint64>(track_));
   if (output_block_number_ && block_number_ > 1)
-    size += EbmlElementSize(libwebm::kMkvCueBlockNumber,
+    size += EbmlElementSize(adhoc::libwebm::kMkvCueBlockNumber,
                             static_cast<uint64>(block_number_));
   const uint64_t track_pos_size =
-      EbmlMasterElementSize(libwebm::kMkvCueTrackPositions, size) + size;
+      EbmlMasterElementSize(adhoc::libwebm::kMkvCueTrackPositions, size) + size;
   const uint64_t payload_size =
-      EbmlElementSize(libwebm::kMkvCueTime, static_cast<uint64>(time_)) +
+      EbmlElementSize(adhoc::libwebm::kMkvCueTime, static_cast<uint64>(time_)) +
       track_pos_size;
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvCuePoint, payload_size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvCuePoint, payload_size))
     return false;
 
   const int64_t payload_position = writer->Position();
   if (payload_position < 0)
     return false;
 
-  if (!WriteEbmlElement(writer, libwebm::kMkvCueTime,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvCueTime,
                         static_cast<uint64>(time_))) {
     return false;
   }
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvCueTrackPositions, size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvCueTrackPositions, size))
     return false;
-  if (!WriteEbmlElement(writer, libwebm::kMkvCueTrack,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvCueTrack,
                         static_cast<uint64>(track_))) {
     return false;
   }
-  if (!WriteEbmlElement(writer, libwebm::kMkvCueClusterPosition,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvCueClusterPosition,
                         static_cast<uint64>(cluster_pos_))) {
     return false;
   }
   if (output_block_number_ && block_number_ > 1) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvCueBlockNumber,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvCueBlockNumber,
                           static_cast<uint64>(block_number_))) {
       return false;
     }
@@ -348,16 +348,16 @@ bool CuePoint::Write(IMkvWriter* writer) const {
 }
 
 uint64_t CuePoint::PayloadSize() const {
-  uint64_t size = EbmlElementSize(libwebm::kMkvCueClusterPosition,
+  uint64_t size = EbmlElementSize(adhoc::libwebm::kMkvCueClusterPosition,
                                   static_cast<uint64>(cluster_pos_));
-  size += EbmlElementSize(libwebm::kMkvCueTrack, static_cast<uint64>(track_));
+  size += EbmlElementSize(adhoc::libwebm::kMkvCueTrack, static_cast<uint64>(track_));
   if (output_block_number_ && block_number_ > 1)
-    size += EbmlElementSize(libwebm::kMkvCueBlockNumber,
+    size += EbmlElementSize(adhoc::libwebm::kMkvCueBlockNumber,
                             static_cast<uint64>(block_number_));
   const uint64_t track_pos_size =
-      EbmlMasterElementSize(libwebm::kMkvCueTrackPositions, size) + size;
+      EbmlMasterElementSize(adhoc::libwebm::kMkvCueTrackPositions, size) + size;
   const uint64_t payload_size =
-      EbmlElementSize(libwebm::kMkvCueTime, static_cast<uint64>(time_)) +
+      EbmlElementSize(adhoc::libwebm::kMkvCueTime, static_cast<uint64>(time_)) +
       track_pos_size;
 
   return payload_size;
@@ -365,7 +365,7 @@ uint64_t CuePoint::PayloadSize() const {
 
 uint64_t CuePoint::Size() const {
   const uint64_t payload_size = PayloadSize();
-  return EbmlMasterElementSize(libwebm::kMkvCuePoint, payload_size) +
+  return EbmlMasterElementSize(adhoc::libwebm::kMkvCuePoint, payload_size) +
          payload_size;
 }
 
@@ -435,7 +435,7 @@ uint64_t Cues::Size() {
   uint64_t size = 0;
   for (int32_t i = 0; i < cue_entries_size_; ++i)
     size += GetCueByIndex(i)->Size();
-  size += EbmlMasterElementSize(libwebm::kMkvCues, size);
+  size += EbmlMasterElementSize(adhoc::libwebm::kMkvCues, size);
   return size;
 }
 
@@ -453,7 +453,7 @@ bool Cues::Write(IMkvWriter* writer) const {
     size += cue->Size();
   }
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvCues, size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvCues, size))
     return false;
 
   const int64_t payload_position = writer->Position();
@@ -486,7 +486,7 @@ ContentEncAESSettings::ContentEncAESSettings() : cipher_mode_(kCTR) {}
 uint64_t ContentEncAESSettings::Size() const {
   const uint64_t payload = PayloadSize();
   const uint64_t size =
-      EbmlMasterElementSize(libwebm::kMkvContentEncAESSettings, payload) +
+      EbmlMasterElementSize(adhoc::libwebm::kMkvContentEncAESSettings, payload) +
       payload;
   return size;
 }
@@ -494,7 +494,7 @@ uint64_t ContentEncAESSettings::Size() const {
 bool ContentEncAESSettings::Write(IMkvWriter* writer) const {
   const uint64_t payload = PayloadSize();
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvContentEncAESSettings,
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvContentEncAESSettings,
                               payload))
     return false;
 
@@ -502,7 +502,7 @@ bool ContentEncAESSettings::Write(IMkvWriter* writer) const {
   if (payload_position < 0)
     return false;
 
-  if (!WriteEbmlElement(writer, libwebm::kMkvAESSettingsCipherMode,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvAESSettingsCipherMode,
                         static_cast<uint64>(cipher_mode_))) {
     return false;
   }
@@ -516,7 +516,7 @@ bool ContentEncAESSettings::Write(IMkvWriter* writer) const {
 }
 
 uint64_t ContentEncAESSettings::PayloadSize() const {
-  uint64_t size = EbmlElementSize(libwebm::kMkvAESSettingsCipherMode,
+  uint64_t size = EbmlElementSize(adhoc::libwebm::kMkvAESSettingsCipherMode,
                                   static_cast<uint64>(cipher_mode_));
   return size;
 }
@@ -556,7 +556,7 @@ uint64_t ContentEncoding::Size() const {
   const uint64_t encryption_size = EncryptionSize();
   const uint64_t encoding_size = EncodingSize(0, encryption_size);
   const uint64_t encodings_size =
-      EbmlMasterElementSize(libwebm::kMkvContentEncoding, encoding_size) +
+      EbmlMasterElementSize(adhoc::libwebm::kMkvContentEncoding, encoding_size) +
       encoding_size;
 
   return encodings_size;
@@ -566,34 +566,34 @@ bool ContentEncoding::Write(IMkvWriter* writer) const {
   const uint64_t encryption_size = EncryptionSize();
   const uint64_t encoding_size = EncodingSize(0, encryption_size);
   const uint64_t size =
-      EbmlMasterElementSize(libwebm::kMkvContentEncoding, encoding_size) +
+      EbmlMasterElementSize(adhoc::libwebm::kMkvContentEncoding, encoding_size) +
       encoding_size;
 
   const int64_t payload_position = writer->Position();
   if (payload_position < 0)
     return false;
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvContentEncoding,
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvContentEncoding,
                               encoding_size))
     return false;
-  if (!WriteEbmlElement(writer, libwebm::kMkvContentEncodingOrder,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvContentEncodingOrder,
                         static_cast<uint64>(encoding_order_)))
     return false;
-  if (!WriteEbmlElement(writer, libwebm::kMkvContentEncodingScope,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvContentEncodingScope,
                         static_cast<uint64>(encoding_scope_)))
     return false;
-  if (!WriteEbmlElement(writer, libwebm::kMkvContentEncodingType,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvContentEncodingType,
                         static_cast<uint64>(encoding_type_)))
     return false;
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvContentEncryption,
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvContentEncryption,
                               encryption_size))
     return false;
-  if (!WriteEbmlElement(writer, libwebm::kMkvContentEncAlgo,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvContentEncAlgo,
                         static_cast<uint64>(enc_algo_))) {
     return false;
   }
-  if (!WriteEbmlElement(writer, libwebm::kMkvContentEncKeyID, enc_key_id_,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvContentEncKeyID, enc_key_id_,
                         enc_key_id_length_))
     return false;
 
@@ -618,14 +618,14 @@ uint64_t ContentEncoding::EncodingSize(uint64_t compression_size,
 
   if (encryption_size > 0) {
     encoding_size +=
-        EbmlMasterElementSize(libwebm::kMkvContentEncryption, encryption_size) +
+        EbmlMasterElementSize(adhoc::libwebm::kMkvContentEncryption, encryption_size) +
         encryption_size;
   }
-  encoding_size += EbmlElementSize(libwebm::kMkvContentEncodingType,
+  encoding_size += EbmlElementSize(adhoc::libwebm::kMkvContentEncodingType,
                                    static_cast<uint64>(encoding_type_));
-  encoding_size += EbmlElementSize(libwebm::kMkvContentEncodingScope,
+  encoding_size += EbmlElementSize(adhoc::libwebm::kMkvContentEncodingScope,
                                    static_cast<uint64>(encoding_scope_));
-  encoding_size += EbmlElementSize(libwebm::kMkvContentEncodingOrder,
+  encoding_size += EbmlElementSize(adhoc::libwebm::kMkvContentEncodingOrder,
                                    static_cast<uint64>(encoding_order_));
 
   return encoding_size;
@@ -634,9 +634,9 @@ uint64_t ContentEncoding::EncodingSize(uint64_t compression_size,
 uint64_t ContentEncoding::EncryptionSize() const {
   const uint64_t aes_size = enc_aes_settings_.Size();
 
-  uint64_t encryption_size = EbmlElementSize(libwebm::kMkvContentEncKeyID,
+  uint64_t encryption_size = EbmlElementSize(adhoc::libwebm::kMkvContentEncKeyID,
                                              enc_key_id_, enc_key_id_length_);
-  encryption_size += EbmlElementSize(libwebm::kMkvContentEncAlgo,
+  encryption_size += EbmlElementSize(adhoc::libwebm::kMkvContentEncAlgo,
                                      static_cast<uint64>(enc_algo_));
 
   return encryption_size + aes_size;
@@ -716,32 +716,32 @@ ContentEncoding* Track::GetContentEncodingByIndex(uint32_t index) const {
 
 uint64_t Track::PayloadSize() const {
   uint64_t size =
-      EbmlElementSize(libwebm::kMkvTrackNumber, static_cast<uint64>(number_));
-  size += EbmlElementSize(libwebm::kMkvTrackUID, static_cast<uint64>(uid_));
-  size += EbmlElementSize(libwebm::kMkvTrackType, static_cast<uint64>(type_));
+      EbmlElementSize(adhoc::libwebm::kMkvTrackNumber, static_cast<uint64>(number_));
+  size += EbmlElementSize(adhoc::libwebm::kMkvTrackUID, static_cast<uint64>(uid_));
+  size += EbmlElementSize(adhoc::libwebm::kMkvTrackType, static_cast<uint64>(type_));
   if (codec_id_)
-    size += EbmlElementSize(libwebm::kMkvCodecID, codec_id_);
+    size += EbmlElementSize(adhoc::libwebm::kMkvCodecID, codec_id_);
   if (codec_private_)
-    size += EbmlElementSize(libwebm::kMkvCodecPrivate, codec_private_,
+    size += EbmlElementSize(adhoc::libwebm::kMkvCodecPrivate, codec_private_,
                             codec_private_length_);
   if (language_)
-    size += EbmlElementSize(libwebm::kMkvLanguage, language_);
+    size += EbmlElementSize(adhoc::libwebm::kMkvLanguage, language_);
   if (name_)
-    size += EbmlElementSize(libwebm::kMkvName, name_);
+    size += EbmlElementSize(adhoc::libwebm::kMkvName, name_);
   if (max_block_additional_id_) {
-    size += EbmlElementSize(libwebm::kMkvMaxBlockAdditionID,
+    size += EbmlElementSize(adhoc::libwebm::kMkvMaxBlockAdditionID,
                             static_cast<uint64>(max_block_additional_id_));
   }
   if (codec_delay_) {
-    size += EbmlElementSize(libwebm::kMkvCodecDelay,
+    size += EbmlElementSize(adhoc::libwebm::kMkvCodecDelay,
                             static_cast<uint64>(codec_delay_));
   }
   if (seek_pre_roll_) {
-    size += EbmlElementSize(libwebm::kMkvSeekPreRoll,
+    size += EbmlElementSize(adhoc::libwebm::kMkvSeekPreRoll,
                             static_cast<uint64>(seek_pre_roll_));
   }
   if (default_duration_) {
-    size += EbmlElementSize(libwebm::kMkvDefaultDuration,
+    size += EbmlElementSize(adhoc::libwebm::kMkvDefaultDuration,
                             static_cast<uint64>(default_duration_));
   }
 
@@ -752,7 +752,7 @@ uint64_t Track::PayloadSize() const {
       content_encodings_size += encoding->Size();
     }
 
-    size += EbmlMasterElementSize(libwebm::kMkvContentEncodings,
+    size += EbmlMasterElementSize(adhoc::libwebm::kMkvContentEncodings,
                                   content_encodings_size) +
             content_encodings_size;
   }
@@ -762,7 +762,7 @@ uint64_t Track::PayloadSize() const {
 
 uint64_t Track::Size() const {
   uint64_t size = PayloadSize();
-  size += EbmlMasterElementSize(libwebm::kMkvTrackEntry, size);
+  size += EbmlMasterElementSize(adhoc::libwebm::kMkvTrackEntry, size);
   return size;
 }
 
@@ -786,84 +786,84 @@ bool Track::Write(IMkvWriter* writer) const {
   // derived classes may write out more data in the Track element.
   const uint64_t payload_size = PayloadSize();
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvTrackEntry, payload_size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvTrackEntry, payload_size))
     return false;
 
   uint64_t size =
-      EbmlElementSize(libwebm::kMkvTrackNumber, static_cast<uint64>(number_));
-  size += EbmlElementSize(libwebm::kMkvTrackUID, static_cast<uint64>(uid_));
-  size += EbmlElementSize(libwebm::kMkvTrackType, static_cast<uint64>(type_));
+      EbmlElementSize(adhoc::libwebm::kMkvTrackNumber, static_cast<uint64>(number_));
+  size += EbmlElementSize(adhoc::libwebm::kMkvTrackUID, static_cast<uint64>(uid_));
+  size += EbmlElementSize(adhoc::libwebm::kMkvTrackType, static_cast<uint64>(type_));
   if (codec_id_)
-    size += EbmlElementSize(libwebm::kMkvCodecID, codec_id_);
+    size += EbmlElementSize(adhoc::libwebm::kMkvCodecID, codec_id_);
   if (codec_private_)
-    size += EbmlElementSize(libwebm::kMkvCodecPrivate, codec_private_,
+    size += EbmlElementSize(adhoc::libwebm::kMkvCodecPrivate, codec_private_,
                             static_cast<uint64>(codec_private_length_));
   if (language_)
-    size += EbmlElementSize(libwebm::kMkvLanguage, language_);
+    size += EbmlElementSize(adhoc::libwebm::kMkvLanguage, language_);
   if (name_)
-    size += EbmlElementSize(libwebm::kMkvName, name_);
+    size += EbmlElementSize(adhoc::libwebm::kMkvName, name_);
   if (max_block_additional_id_)
-    size += EbmlElementSize(libwebm::kMkvMaxBlockAdditionID,
+    size += EbmlElementSize(adhoc::libwebm::kMkvMaxBlockAdditionID,
                             static_cast<uint64>(max_block_additional_id_));
   if (codec_delay_)
-    size += EbmlElementSize(libwebm::kMkvCodecDelay,
+    size += EbmlElementSize(adhoc::libwebm::kMkvCodecDelay,
                             static_cast<uint64>(codec_delay_));
   if (seek_pre_roll_)
-    size += EbmlElementSize(libwebm::kMkvSeekPreRoll,
+    size += EbmlElementSize(adhoc::libwebm::kMkvSeekPreRoll,
                             static_cast<uint64>(seek_pre_roll_));
   if (default_duration_)
-    size += EbmlElementSize(libwebm::kMkvDefaultDuration,
+    size += EbmlElementSize(adhoc::libwebm::kMkvDefaultDuration,
                             static_cast<uint64>(default_duration_));
 
   const int64_t payload_position = writer->Position();
   if (payload_position < 0)
     return false;
 
-  if (!WriteEbmlElement(writer, libwebm::kMkvTrackNumber,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvTrackNumber,
                         static_cast<uint64>(number_)))
     return false;
-  if (!WriteEbmlElement(writer, libwebm::kMkvTrackUID,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvTrackUID,
                         static_cast<uint64>(uid_)))
     return false;
-  if (!WriteEbmlElement(writer, libwebm::kMkvTrackType,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvTrackType,
                         static_cast<uint64>(type_)))
     return false;
   if (max_block_additional_id_) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvMaxBlockAdditionID,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvMaxBlockAdditionID,
                           static_cast<uint64>(max_block_additional_id_))) {
       return false;
     }
   }
   if (codec_delay_) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvCodecDelay,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvCodecDelay,
                           static_cast<uint64>(codec_delay_)))
       return false;
   }
   if (seek_pre_roll_) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvSeekPreRoll,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvSeekPreRoll,
                           static_cast<uint64>(seek_pre_roll_)))
       return false;
   }
   if (default_duration_) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvDefaultDuration,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvDefaultDuration,
                           static_cast<uint64>(default_duration_)))
       return false;
   }
   if (codec_id_) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvCodecID, codec_id_))
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvCodecID, codec_id_))
       return false;
   }
   if (codec_private_) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvCodecPrivate, codec_private_,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvCodecPrivate, codec_private_,
                           static_cast<uint64>(codec_private_length_)))
       return false;
   }
   if (language_) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvLanguage, language_))
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvLanguage, language_))
       return false;
   }
   if (name_) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvName, name_))
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvName, name_))
       return false;
   }
 
@@ -879,7 +879,7 @@ bool Track::Write(IMkvWriter* writer) const {
       content_encodings_size += encoding->Size();
     }
 
-    if (!WriteEbmlMasterElement(writer, libwebm::kMkvContentEncodings,
+    if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvContentEncodings,
                                 content_encodings_size))
       return false;
 
@@ -958,12 +958,12 @@ void Track::set_name(const char* name) {
 // Colour and its child elements
 
 uint64_t PrimaryChromaticity::PrimaryChromaticitySize(
-    libwebm::MkvId x_id, libwebm::MkvId y_id) const {
+    adhoc::libwebm::MkvId x_id, adhoc::libwebm::MkvId y_id) const {
   return EbmlElementSize(x_id, x_) + EbmlElementSize(y_id, y_);
 }
 
-bool PrimaryChromaticity::Write(IMkvWriter* writer, libwebm::MkvId x_id,
-                                libwebm::MkvId y_id) const {
+bool PrimaryChromaticity::Write(IMkvWriter* writer, adhoc::libwebm::MkvId x_id,
+                                adhoc::libwebm::MkvId y_id) const {
   if (!Valid()) {
     return false;
   }
@@ -980,7 +980,7 @@ uint64_t MasteringMetadata::MasteringMetadataSize() const {
   uint64_t size = PayloadSize();
 
   if (size > 0)
-    size += EbmlMasterElementSize(libwebm::kMkvMasteringMetadata, size);
+    size += EbmlMasterElementSize(adhoc::libwebm::kMkvMasteringMetadata, size);
 
   return size;
 }
@@ -1017,31 +1017,31 @@ bool MasteringMetadata::Write(IMkvWriter* writer) const {
   if (size == 0)
     return true;
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvMasteringMetadata, size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvMasteringMetadata, size))
     return false;
   if (luminance_max_ != kValueNotPresent &&
-      !WriteEbmlElement(writer, libwebm::kMkvLuminanceMax, luminance_max_)) {
+      !WriteEbmlElement(writer, adhoc::libwebm::kMkvLuminanceMax, luminance_max_)) {
     return false;
   }
   if (luminance_min_ != kValueNotPresent &&
-      !WriteEbmlElement(writer, libwebm::kMkvLuminanceMin, luminance_min_)) {
+      !WriteEbmlElement(writer, adhoc::libwebm::kMkvLuminanceMin, luminance_min_)) {
     return false;
   }
-  if (r_ && !r_->Write(writer, libwebm::kMkvPrimaryRChromaticityX,
-                       libwebm::kMkvPrimaryRChromaticityY)) {
+  if (r_ && !r_->Write(writer, adhoc::libwebm::kMkvPrimaryRChromaticityX,
+                       adhoc::libwebm::kMkvPrimaryRChromaticityY)) {
     return false;
   }
-  if (g_ && !g_->Write(writer, libwebm::kMkvPrimaryGChromaticityX,
-                       libwebm::kMkvPrimaryGChromaticityY)) {
+  if (g_ && !g_->Write(writer, adhoc::libwebm::kMkvPrimaryGChromaticityX,
+                       adhoc::libwebm::kMkvPrimaryGChromaticityY)) {
     return false;
   }
-  if (b_ && !b_->Write(writer, libwebm::kMkvPrimaryBChromaticityX,
-                       libwebm::kMkvPrimaryBChromaticityY)) {
+  if (b_ && !b_->Write(writer, adhoc::libwebm::kMkvPrimaryBChromaticityX,
+                       adhoc::libwebm::kMkvPrimaryBChromaticityY)) {
     return false;
   }
   if (white_point_ &&
-      !white_point_->Write(writer, libwebm::kMkvWhitePointChromaticityX,
-                           libwebm::kMkvWhitePointChromaticityY)) {
+      !white_point_->Write(writer, adhoc::libwebm::kMkvWhitePointChromaticityX,
+                           adhoc::libwebm::kMkvWhitePointChromaticityY)) {
     return false;
   }
 
@@ -1083,26 +1083,26 @@ uint64_t MasteringMetadata::PayloadSize() const {
   uint64_t size = 0;
 
   if (luminance_max_ != kValueNotPresent)
-    size += EbmlElementSize(libwebm::kMkvLuminanceMax, luminance_max_);
+    size += EbmlElementSize(adhoc::libwebm::kMkvLuminanceMax, luminance_max_);
   if (luminance_min_ != kValueNotPresent)
-    size += EbmlElementSize(libwebm::kMkvLuminanceMin, luminance_min_);
+    size += EbmlElementSize(adhoc::libwebm::kMkvLuminanceMin, luminance_min_);
 
   if (r_) {
-    size += r_->PrimaryChromaticitySize(libwebm::kMkvPrimaryRChromaticityX,
-                                        libwebm::kMkvPrimaryRChromaticityY);
+    size += r_->PrimaryChromaticitySize(adhoc::libwebm::kMkvPrimaryRChromaticityX,
+                                        adhoc::libwebm::kMkvPrimaryRChromaticityY);
   }
   if (g_) {
-    size += g_->PrimaryChromaticitySize(libwebm::kMkvPrimaryGChromaticityX,
-                                        libwebm::kMkvPrimaryGChromaticityY);
+    size += g_->PrimaryChromaticitySize(adhoc::libwebm::kMkvPrimaryGChromaticityX,
+                                        adhoc::libwebm::kMkvPrimaryGChromaticityY);
   }
   if (b_) {
-    size += b_->PrimaryChromaticitySize(libwebm::kMkvPrimaryBChromaticityX,
-                                        libwebm::kMkvPrimaryBChromaticityY);
+    size += b_->PrimaryChromaticitySize(adhoc::libwebm::kMkvPrimaryBChromaticityX,
+                                        adhoc::libwebm::kMkvPrimaryBChromaticityY);
   }
   if (white_point_) {
     size += white_point_->PrimaryChromaticitySize(
-        libwebm::kMkvWhitePointChromaticityX,
-        libwebm::kMkvWhitePointChromaticityY);
+        adhoc::libwebm::kMkvWhitePointChromaticityX,
+        adhoc::libwebm::kMkvWhitePointChromaticityY);
   }
 
   return size;
@@ -1112,7 +1112,7 @@ uint64_t Colour::ColourSize() const {
   uint64_t size = PayloadSize();
 
   if (size > 0)
-    size += EbmlMasterElementSize(libwebm::kMkvColour, size);
+    size += EbmlMasterElementSize(adhoc::libwebm::kMkvColour, size);
 
   return size;
 }
@@ -1155,72 +1155,72 @@ bool Colour::Write(IMkvWriter* writer) const {
   if (!Valid())
     return false;
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvColour, size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvColour, size))
     return false;
 
   if (matrix_coefficients_ != kValueNotPresent &&
-      !WriteEbmlElement(writer, libwebm::kMkvMatrixCoefficients,
+      !WriteEbmlElement(writer, adhoc::libwebm::kMkvMatrixCoefficients,
                         static_cast<uint64>(matrix_coefficients_))) {
     return false;
   }
   if (bits_per_channel_ != kValueNotPresent &&
-      !WriteEbmlElement(writer, libwebm::kMkvBitsPerChannel,
+      !WriteEbmlElement(writer, adhoc::libwebm::kMkvBitsPerChannel,
                         static_cast<uint64>(bits_per_channel_))) {
     return false;
   }
   if (chroma_subsampling_horz_ != kValueNotPresent &&
-      !WriteEbmlElement(writer, libwebm::kMkvChromaSubsamplingHorz,
+      !WriteEbmlElement(writer, adhoc::libwebm::kMkvChromaSubsamplingHorz,
                         static_cast<uint64>(chroma_subsampling_horz_))) {
     return false;
   }
   if (chroma_subsampling_vert_ != kValueNotPresent &&
-      !WriteEbmlElement(writer, libwebm::kMkvChromaSubsamplingVert,
+      !WriteEbmlElement(writer, adhoc::libwebm::kMkvChromaSubsamplingVert,
                         static_cast<uint64>(chroma_subsampling_vert_))) {
     return false;
   }
 
   if (cb_subsampling_horz_ != kValueNotPresent &&
-      !WriteEbmlElement(writer, libwebm::kMkvCbSubsamplingHorz,
+      !WriteEbmlElement(writer, adhoc::libwebm::kMkvCbSubsamplingHorz,
                         static_cast<uint64>(cb_subsampling_horz_))) {
     return false;
   }
   if (cb_subsampling_vert_ != kValueNotPresent &&
-      !WriteEbmlElement(writer, libwebm::kMkvCbSubsamplingVert,
+      !WriteEbmlElement(writer, adhoc::libwebm::kMkvCbSubsamplingVert,
                         static_cast<uint64>(cb_subsampling_vert_))) {
     return false;
   }
   if (chroma_siting_horz_ != kValueNotPresent &&
-      !WriteEbmlElement(writer, libwebm::kMkvChromaSitingHorz,
+      !WriteEbmlElement(writer, adhoc::libwebm::kMkvChromaSitingHorz,
                         static_cast<uint64>(chroma_siting_horz_))) {
     return false;
   }
   if (chroma_siting_vert_ != kValueNotPresent &&
-      !WriteEbmlElement(writer, libwebm::kMkvChromaSitingVert,
+      !WriteEbmlElement(writer, adhoc::libwebm::kMkvChromaSitingVert,
                         static_cast<uint64>(chroma_siting_vert_))) {
     return false;
   }
   if (range_ != kValueNotPresent &&
-      !WriteEbmlElement(writer, libwebm::kMkvRange,
+      !WriteEbmlElement(writer, adhoc::libwebm::kMkvRange,
                         static_cast<uint64>(range_))) {
     return false;
   }
   if (transfer_characteristics_ != kValueNotPresent &&
-      !WriteEbmlElement(writer, libwebm::kMkvTransferCharacteristics,
+      !WriteEbmlElement(writer, adhoc::libwebm::kMkvTransferCharacteristics,
                         static_cast<uint64>(transfer_characteristics_))) {
     return false;
   }
   if (primaries_ != kValueNotPresent &&
-      !WriteEbmlElement(writer, libwebm::kMkvPrimaries,
+      !WriteEbmlElement(writer, adhoc::libwebm::kMkvPrimaries,
                         static_cast<uint64>(primaries_))) {
     return false;
   }
   if (max_cll_ != kValueNotPresent &&
-      !WriteEbmlElement(writer, libwebm::kMkvMaxCLL,
+      !WriteEbmlElement(writer, adhoc::libwebm::kMkvMaxCLL,
                         static_cast<uint64>(max_cll_))) {
     return false;
   }
   if (max_fall_ != kValueNotPresent &&
-      !WriteEbmlElement(writer, libwebm::kMkvMaxFALL,
+      !WriteEbmlElement(writer, adhoc::libwebm::kMkvMaxFALL,
                         static_cast<uint64>(max_fall_))) {
     return false;
   }
@@ -1254,54 +1254,54 @@ uint64_t Colour::PayloadSize() const {
   uint64_t size = 0;
 
   if (matrix_coefficients_ != kValueNotPresent) {
-    size += EbmlElementSize(libwebm::kMkvMatrixCoefficients,
+    size += EbmlElementSize(adhoc::libwebm::kMkvMatrixCoefficients,
                             static_cast<uint64>(matrix_coefficients_));
   }
   if (bits_per_channel_ != kValueNotPresent) {
-    size += EbmlElementSize(libwebm::kMkvBitsPerChannel,
+    size += EbmlElementSize(adhoc::libwebm::kMkvBitsPerChannel,
                             static_cast<uint64>(bits_per_channel_));
   }
   if (chroma_subsampling_horz_ != kValueNotPresent) {
-    size += EbmlElementSize(libwebm::kMkvChromaSubsamplingHorz,
+    size += EbmlElementSize(adhoc::libwebm::kMkvChromaSubsamplingHorz,
                             static_cast<uint64>(chroma_subsampling_horz_));
   }
   if (chroma_subsampling_vert_ != kValueNotPresent) {
-    size += EbmlElementSize(libwebm::kMkvChromaSubsamplingVert,
+    size += EbmlElementSize(adhoc::libwebm::kMkvChromaSubsamplingVert,
                             static_cast<uint64>(chroma_subsampling_vert_));
   }
   if (cb_subsampling_horz_ != kValueNotPresent) {
-    size += EbmlElementSize(libwebm::kMkvCbSubsamplingHorz,
+    size += EbmlElementSize(adhoc::libwebm::kMkvCbSubsamplingHorz,
                             static_cast<uint64>(cb_subsampling_horz_));
   }
   if (cb_subsampling_vert_ != kValueNotPresent) {
-    size += EbmlElementSize(libwebm::kMkvCbSubsamplingVert,
+    size += EbmlElementSize(adhoc::libwebm::kMkvCbSubsamplingVert,
                             static_cast<uint64>(cb_subsampling_vert_));
   }
   if (chroma_siting_horz_ != kValueNotPresent) {
-    size += EbmlElementSize(libwebm::kMkvChromaSitingHorz,
+    size += EbmlElementSize(adhoc::libwebm::kMkvChromaSitingHorz,
                             static_cast<uint64>(chroma_siting_horz_));
   }
   if (chroma_siting_vert_ != kValueNotPresent) {
-    size += EbmlElementSize(libwebm::kMkvChromaSitingVert,
+    size += EbmlElementSize(adhoc::libwebm::kMkvChromaSitingVert,
                             static_cast<uint64>(chroma_siting_vert_));
   }
   if (range_ != kValueNotPresent) {
-    size += EbmlElementSize(libwebm::kMkvRange, static_cast<uint64>(range_));
+    size += EbmlElementSize(adhoc::libwebm::kMkvRange, static_cast<uint64>(range_));
   }
   if (transfer_characteristics_ != kValueNotPresent) {
-    size += EbmlElementSize(libwebm::kMkvTransferCharacteristics,
+    size += EbmlElementSize(adhoc::libwebm::kMkvTransferCharacteristics,
                             static_cast<uint64>(transfer_characteristics_));
   }
   if (primaries_ != kValueNotPresent) {
-    size += EbmlElementSize(libwebm::kMkvPrimaries,
+    size += EbmlElementSize(adhoc::libwebm::kMkvPrimaries,
                             static_cast<uint64>(primaries_));
   }
   if (max_cll_ != kValueNotPresent) {
-    size += EbmlElementSize(libwebm::kMkvMaxCLL, static_cast<uint64>(max_cll_));
+    size += EbmlElementSize(adhoc::libwebm::kMkvMaxCLL, static_cast<uint64>(max_cll_));
   }
   if (max_fall_ != kValueNotPresent) {
     size +=
-        EbmlElementSize(libwebm::kMkvMaxFALL, static_cast<uint64>(max_fall_));
+        EbmlElementSize(adhoc::libwebm::kMkvMaxFALL, static_cast<uint64>(max_fall_));
   }
 
   if (mastering_metadata_)
@@ -1318,7 +1318,7 @@ uint64_t Projection::ProjectionSize() const {
   uint64_t size = PayloadSize();
 
   if (size > 0)
-    size += EbmlMasterElementSize(libwebm::kMkvProjection, size);
+    size += EbmlMasterElementSize(adhoc::libwebm::kMkvProjection, size);
 
   return size;
 }
@@ -1330,29 +1330,29 @@ bool Projection::Write(IMkvWriter* writer) const {
   if (size == 0)
     return true;
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvProjection, size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvProjection, size))
     return false;
 
-  if (!WriteEbmlElement(writer, libwebm::kMkvProjectionType,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvProjectionType,
                         static_cast<uint64>(type_))) {
     return false;
   }
 
   if (private_data_length_ > 0 && private_data_ != NULL &&
-      !WriteEbmlElement(writer, libwebm::kMkvProjectionPrivate, private_data_,
+      !WriteEbmlElement(writer, adhoc::libwebm::kMkvProjectionPrivate, private_data_,
                         private_data_length_)) {
     return false;
   }
 
-  if (!WriteEbmlElement(writer, libwebm::kMkvProjectionPoseYaw, pose_yaw_))
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvProjectionPoseYaw, pose_yaw_))
     return false;
 
-  if (!WriteEbmlElement(writer, libwebm::kMkvProjectionPosePitch,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvProjectionPosePitch,
                         pose_pitch_)) {
     return false;
   }
 
-  if (!WriteEbmlElement(writer, libwebm::kMkvProjectionPoseRoll, pose_roll_)) {
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvProjectionPoseRoll, pose_roll_)) {
     return false;
   }
 
@@ -1385,16 +1385,16 @@ bool Projection::SetProjectionPrivate(const uint8_t* data,
 
 uint64_t Projection::PayloadSize() const {
   uint64_t size =
-      EbmlElementSize(libwebm::kMkvProjection, static_cast<uint64>(type_));
+      EbmlElementSize(adhoc::libwebm::kMkvProjection, static_cast<uint64>(type_));
 
   if (private_data_length_ > 0 && private_data_ != NULL) {
-    size += EbmlElementSize(libwebm::kMkvProjectionPrivate, private_data_,
+    size += EbmlElementSize(adhoc::libwebm::kMkvProjectionPrivate, private_data_,
                             private_data_length_);
   }
 
-  size += EbmlElementSize(libwebm::kMkvProjectionPoseYaw, pose_yaw_);
-  size += EbmlElementSize(libwebm::kMkvProjectionPosePitch, pose_pitch_);
-  size += EbmlElementSize(libwebm::kMkvProjectionPoseRoll, pose_roll_);
+  size += EbmlElementSize(adhoc::libwebm::kMkvProjectionPoseYaw, pose_yaw_);
+  size += EbmlElementSize(adhoc::libwebm::kMkvProjectionPosePitch, pose_pitch_);
+  size += EbmlElementSize(adhoc::libwebm::kMkvProjectionPoseRoll, pose_roll_);
 
   return size;
 }
@@ -1450,7 +1450,7 @@ uint64_t VideoTrack::PayloadSize() const {
   const uint64_t parent_size = Track::PayloadSize();
 
   uint64_t size = VideoPayloadSize();
-  size += EbmlMasterElementSize(libwebm::kMkvVideo, size);
+  size += EbmlMasterElementSize(adhoc::libwebm::kMkvVideo, size);
 
   return parent_size + size;
 }
@@ -1461,7 +1461,7 @@ bool VideoTrack::Write(IMkvWriter* writer) const {
 
   const uint64_t size = VideoPayloadSize();
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvVideo, size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvVideo, size))
     return false;
 
   const int64_t payload_position = writer->Position();
@@ -1469,59 +1469,59 @@ bool VideoTrack::Write(IMkvWriter* writer) const {
     return false;
 
   if (!WriteEbmlElement(
-          writer, libwebm::kMkvPixelWidth,
+          writer, adhoc::libwebm::kMkvPixelWidth,
           static_cast<uint64>((pixel_width_ > 0) ? pixel_width_ : width_)))
     return false;
   if (!WriteEbmlElement(
-          writer, libwebm::kMkvPixelHeight,
+          writer, adhoc::libwebm::kMkvPixelHeight,
           static_cast<uint64>((pixel_height_ > 0) ? pixel_height_ : height_)))
     return false;
   if (display_width_ > 0) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvDisplayWidth,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvDisplayWidth,
                           static_cast<uint64>(display_width_)))
       return false;
   }
   if (display_height_ > 0) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvDisplayHeight,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvDisplayHeight,
                           static_cast<uint64>(display_height_)))
       return false;
   }
   if (crop_left_ > 0) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvPixelCropLeft,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvPixelCropLeft,
                           static_cast<uint64>(crop_left_)))
       return false;
   }
   if (crop_right_ > 0) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvPixelCropRight,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvPixelCropRight,
                           static_cast<uint64>(crop_right_)))
       return false;
   }
   if (crop_top_ > 0) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvPixelCropTop,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvPixelCropTop,
                           static_cast<uint64>(crop_top_)))
       return false;
   }
   if (crop_bottom_ > 0) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvPixelCropBottom,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvPixelCropBottom,
                           static_cast<uint64>(crop_bottom_)))
       return false;
   }
   if (stereo_mode_ > kMono) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvStereoMode,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvStereoMode,
                           static_cast<uint64>(stereo_mode_)))
       return false;
   }
   if (alpha_mode_ > kNoAlpha) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvAlphaMode,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvAlphaMode,
                           static_cast<uint64>(alpha_mode_)))
       return false;
   }
   if (colour_space_) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvColourSpace, colour_space_))
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvColourSpace, colour_space_))
       return false;
   }
   if (frame_rate_ > 0.0) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvFrameRate,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvFrameRate,
                           static_cast<float>(frame_rate_))) {
       return false;
     }
@@ -1608,40 +1608,40 @@ bool VideoTrack::SetProjection(const Projection& projection) {
 
 uint64_t VideoTrack::VideoPayloadSize() const {
   uint64_t size = EbmlElementSize(
-      libwebm::kMkvPixelWidth,
+      adhoc::libwebm::kMkvPixelWidth,
       static_cast<uint64>((pixel_width_ > 0) ? pixel_width_ : width_));
   size += EbmlElementSize(
-      libwebm::kMkvPixelHeight,
+      adhoc::libwebm::kMkvPixelHeight,
       static_cast<uint64>((pixel_height_ > 0) ? pixel_height_ : height_));
   if (display_width_ > 0)
-    size += EbmlElementSize(libwebm::kMkvDisplayWidth,
+    size += EbmlElementSize(adhoc::libwebm::kMkvDisplayWidth,
                             static_cast<uint64>(display_width_));
   if (display_height_ > 0)
-    size += EbmlElementSize(libwebm::kMkvDisplayHeight,
+    size += EbmlElementSize(adhoc::libwebm::kMkvDisplayHeight,
                             static_cast<uint64>(display_height_));
   if (crop_left_ > 0)
-    size += EbmlElementSize(libwebm::kMkvPixelCropLeft,
+    size += EbmlElementSize(adhoc::libwebm::kMkvPixelCropLeft,
                             static_cast<uint64>(crop_left_));
   if (crop_right_ > 0)
-    size += EbmlElementSize(libwebm::kMkvPixelCropRight,
+    size += EbmlElementSize(adhoc::libwebm::kMkvPixelCropRight,
                             static_cast<uint64>(crop_right_));
   if (crop_top_ > 0)
-    size += EbmlElementSize(libwebm::kMkvPixelCropTop,
+    size += EbmlElementSize(adhoc::libwebm::kMkvPixelCropTop,
                             static_cast<uint64>(crop_top_));
   if (crop_bottom_ > 0)
-    size += EbmlElementSize(libwebm::kMkvPixelCropBottom,
+    size += EbmlElementSize(adhoc::libwebm::kMkvPixelCropBottom,
                             static_cast<uint64>(crop_bottom_));
   if (stereo_mode_ > kMono)
-    size += EbmlElementSize(libwebm::kMkvStereoMode,
+    size += EbmlElementSize(adhoc::libwebm::kMkvStereoMode,
                             static_cast<uint64>(stereo_mode_));
   if (alpha_mode_ > kNoAlpha)
-    size += EbmlElementSize(libwebm::kMkvAlphaMode,
+    size += EbmlElementSize(adhoc::libwebm::kMkvAlphaMode,
                             static_cast<uint64>(alpha_mode_));
   if (frame_rate_ > 0.0)
-    size += EbmlElementSize(libwebm::kMkvFrameRate,
+    size += EbmlElementSize(adhoc::libwebm::kMkvFrameRate,
                             static_cast<float>(frame_rate_));
   if (colour_space_)
-    size += EbmlElementSize(libwebm::kMkvColourSpace, colour_space_);
+    size += EbmlElementSize(adhoc::libwebm::kMkvColourSpace, colour_space_);
   if (colour_)
     size += colour_->ColourSize();
   if (projection_)
@@ -1662,14 +1662,14 @@ AudioTrack::~AudioTrack() {}
 uint64_t AudioTrack::PayloadSize() const {
   const uint64_t parent_size = Track::PayloadSize();
 
-  uint64_t size = EbmlElementSize(libwebm::kMkvSamplingFrequency,
+  uint64_t size = EbmlElementSize(adhoc::libwebm::kMkvSamplingFrequency,
                                   static_cast<float>(sample_rate_));
   size +=
-      EbmlElementSize(libwebm::kMkvChannels, static_cast<uint64>(channels_));
+      EbmlElementSize(adhoc::libwebm::kMkvChannels, static_cast<uint64>(channels_));
   if (bit_depth_ > 0)
     size +=
-        EbmlElementSize(libwebm::kMkvBitDepth, static_cast<uint64>(bit_depth_));
-  size += EbmlMasterElementSize(libwebm::kMkvAudio, size);
+        EbmlElementSize(adhoc::libwebm::kMkvBitDepth, static_cast<uint64>(bit_depth_));
+  size += EbmlMasterElementSize(adhoc::libwebm::kMkvAudio, size);
 
   return parent_size + size;
 }
@@ -1679,29 +1679,29 @@ bool AudioTrack::Write(IMkvWriter* writer) const {
     return false;
 
   // Calculate AudioSettings size.
-  uint64_t size = EbmlElementSize(libwebm::kMkvSamplingFrequency,
+  uint64_t size = EbmlElementSize(adhoc::libwebm::kMkvSamplingFrequency,
                                   static_cast<float>(sample_rate_));
   size +=
-      EbmlElementSize(libwebm::kMkvChannels, static_cast<uint64>(channels_));
+      EbmlElementSize(adhoc::libwebm::kMkvChannels, static_cast<uint64>(channels_));
   if (bit_depth_ > 0)
     size +=
-        EbmlElementSize(libwebm::kMkvBitDepth, static_cast<uint64>(bit_depth_));
+        EbmlElementSize(adhoc::libwebm::kMkvBitDepth, static_cast<uint64>(bit_depth_));
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvAudio, size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvAudio, size))
     return false;
 
   const int64_t payload_position = writer->Position();
   if (payload_position < 0)
     return false;
 
-  if (!WriteEbmlElement(writer, libwebm::kMkvSamplingFrequency,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvSamplingFrequency,
                         static_cast<float>(sample_rate_)))
     return false;
-  if (!WriteEbmlElement(writer, libwebm::kMkvChannels,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvChannels,
                         static_cast<uint64>(channels_)))
     return false;
   if (bit_depth_ > 0)
-    if (!WriteEbmlElement(writer, libwebm::kMkvBitDepth,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvBitDepth,
                           static_cast<uint64>(bit_depth_)))
       return false;
 
@@ -1849,7 +1849,7 @@ bool Tracks::Write(IMkvWriter* writer) const {
     size += track->Size();
   }
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvTracks, size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvTracks, size))
     return false;
 
   const int64_t payload_position = writer->Position();
@@ -1977,11 +1977,11 @@ bool Chapter::ExpandDisplaysArray() {
 
 uint64_t Chapter::WriteAtom(IMkvWriter* writer) const {
   uint64_t payload_size =
-      EbmlElementSize(libwebm::kMkvChapterStringUID, id_) +
-      EbmlElementSize(libwebm::kMkvChapterUID, static_cast<uint64>(uid_)) +
-      EbmlElementSize(libwebm::kMkvChapterTimeStart,
+      EbmlElementSize(adhoc::libwebm::kMkvChapterStringUID, id_) +
+      EbmlElementSize(adhoc::libwebm::kMkvChapterUID, static_cast<uint64>(uid_)) +
+      EbmlElementSize(adhoc::libwebm::kMkvChapterTimeStart,
                       static_cast<uint64>(start_timecode_)) +
-      EbmlElementSize(libwebm::kMkvChapterTimeEnd,
+      EbmlElementSize(adhoc::libwebm::kMkvChapterTimeEnd,
                       static_cast<uint64>(end_timecode_));
 
   for (int idx = 0; idx < displays_count_; ++idx) {
@@ -1990,7 +1990,7 @@ uint64_t Chapter::WriteAtom(IMkvWriter* writer) const {
   }
 
   const uint64_t atom_size =
-      EbmlMasterElementSize(libwebm::kMkvChapterAtom, payload_size) +
+      EbmlMasterElementSize(adhoc::libwebm::kMkvChapterAtom, payload_size) +
       payload_size;
 
   if (writer == NULL)
@@ -1998,21 +1998,21 @@ uint64_t Chapter::WriteAtom(IMkvWriter* writer) const {
 
   const int64_t start = writer->Position();
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvChapterAtom, payload_size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvChapterAtom, payload_size))
     return 0;
 
-  if (!WriteEbmlElement(writer, libwebm::kMkvChapterStringUID, id_))
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvChapterStringUID, id_))
     return 0;
 
-  if (!WriteEbmlElement(writer, libwebm::kMkvChapterUID,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvChapterUID,
                         static_cast<uint64>(uid_)))
     return 0;
 
-  if (!WriteEbmlElement(writer, libwebm::kMkvChapterTimeStart,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvChapterTimeStart,
                         static_cast<uint64>(start_timecode_)))
     return 0;
 
-  if (!WriteEbmlElement(writer, libwebm::kMkvChapterTimeEnd,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvChapterTimeEnd,
                         static_cast<uint64>(end_timecode_)))
     return 0;
 
@@ -2056,16 +2056,16 @@ bool Chapter::Display::set_country(const char* country) {
 }
 
 uint64_t Chapter::Display::WriteDisplay(IMkvWriter* writer) const {
-  uint64_t payload_size = EbmlElementSize(libwebm::kMkvChapString, title_);
+  uint64_t payload_size = EbmlElementSize(adhoc::libwebm::kMkvChapString, title_);
 
   if (language_)
-    payload_size += EbmlElementSize(libwebm::kMkvChapLanguage, language_);
+    payload_size += EbmlElementSize(adhoc::libwebm::kMkvChapLanguage, language_);
 
   if (country_)
-    payload_size += EbmlElementSize(libwebm::kMkvChapCountry, country_);
+    payload_size += EbmlElementSize(adhoc::libwebm::kMkvChapCountry, country_);
 
   const uint64_t display_size =
-      EbmlMasterElementSize(libwebm::kMkvChapterDisplay, payload_size) +
+      EbmlMasterElementSize(adhoc::libwebm::kMkvChapterDisplay, payload_size) +
       payload_size;
 
   if (writer == NULL)
@@ -2073,20 +2073,20 @@ uint64_t Chapter::Display::WriteDisplay(IMkvWriter* writer) const {
 
   const int64_t start = writer->Position();
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvChapterDisplay,
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvChapterDisplay,
                               payload_size))
     return 0;
 
-  if (!WriteEbmlElement(writer, libwebm::kMkvChapString, title_))
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvChapString, title_))
     return 0;
 
   if (language_) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvChapLanguage, language_))
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvChapLanguage, language_))
       return 0;
   }
 
   if (country_) {
-    if (!WriteEbmlElement(writer, libwebm::kMkvChapCountry, country_))
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvChapCountry, country_))
       return 0;
   }
 
@@ -2132,7 +2132,7 @@ bool Chapters::Write(IMkvWriter* writer) const {
 
   const uint64_t payload_size = WriteEdition(NULL);  // return size only
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvChapters, payload_size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvChapters, payload_size))
     return false;
 
   const int64_t start = writer->Position();
@@ -2181,7 +2181,7 @@ uint64_t Chapters::WriteEdition(IMkvWriter* writer) const {
   }
 
   const uint64_t edition_size =
-      EbmlMasterElementSize(libwebm::kMkvEditionEntry, payload_size) +
+      EbmlMasterElementSize(adhoc::libwebm::kMkvEditionEntry, payload_size) +
       payload_size;
 
   if (writer == NULL)  // return size only
@@ -2189,7 +2189,7 @@ uint64_t Chapters::WriteEdition(IMkvWriter* writer) const {
 
   const int64_t start = writer->Position();
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvEditionEntry, payload_size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvEditionEntry, payload_size))
     return 0;  // error
 
   for (int idx = 0; idx < chapters_count_; ++idx) {
@@ -2283,14 +2283,14 @@ uint64_t Tag::Write(IMkvWriter* writer) const {
   }
 
   const uint64_t tag_size =
-      EbmlMasterElementSize(libwebm::kMkvTag, payload_size) + payload_size;
+      EbmlMasterElementSize(adhoc::libwebm::kMkvTag, payload_size) + payload_size;
 
   if (writer == NULL)
     return tag_size;
 
   const int64_t start = writer->Position();
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvTag, payload_size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvTag, payload_size))
     return 0;
 
   for (int idx = 0; idx < simple_tags_count_; ++idx) {
@@ -2329,12 +2329,12 @@ bool Tag::SimpleTag::set_tag_string(const char* tag_string) {
 }
 
 uint64_t Tag::SimpleTag::Write(IMkvWriter* writer) const {
-  uint64_t payload_size = EbmlElementSize(libwebm::kMkvTagName, tag_name_);
+  uint64_t payload_size = EbmlElementSize(adhoc::libwebm::kMkvTagName, tag_name_);
 
-  payload_size += EbmlElementSize(libwebm::kMkvTagString, tag_string_);
+  payload_size += EbmlElementSize(adhoc::libwebm::kMkvTagString, tag_string_);
 
   const uint64_t simple_tag_size =
-      EbmlMasterElementSize(libwebm::kMkvSimpleTag, payload_size) +
+      EbmlMasterElementSize(adhoc::libwebm::kMkvSimpleTag, payload_size) +
       payload_size;
 
   if (writer == NULL)
@@ -2342,13 +2342,13 @@ uint64_t Tag::SimpleTag::Write(IMkvWriter* writer) const {
 
   const int64_t start = writer->Position();
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvSimpleTag, payload_size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvSimpleTag, payload_size))
     return 0;
 
-  if (!WriteEbmlElement(writer, libwebm::kMkvTagName, tag_name_))
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvTagName, tag_name_))
     return 0;
 
-  if (!WriteEbmlElement(writer, libwebm::kMkvTagString, tag_string_))
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvTagString, tag_string_))
     return 0;
 
   const int64_t stop = writer->Position();
@@ -2395,7 +2395,7 @@ bool Tags::Write(IMkvWriter* writer) const {
     payload_size += tag.Write(NULL);
   }
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvTags, payload_size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvTags, payload_size))
     return false;
 
   const int64_t start = writer->Position();
@@ -2611,7 +2611,7 @@ bool Cluster::Finalize(bool set_last_frame_duration, uint64_t duration) {
 
 uint64_t Cluster::Size() const {
   const uint64_t element_size =
-      EbmlMasterElementSize(libwebm::kMkvCluster, 0xFFFFFFFFFFFFFFFFULL) +
+      EbmlMasterElementSize(adhoc::libwebm::kMkvCluster, 0xFFFFFFFFFFFFFFFFULL) +
       payload_size_;
   return element_size;
 }
@@ -2719,7 +2719,7 @@ bool Cluster::WriteClusterHeader() {
   if (finalized_)
     return false;
 
-  if (WriteID(writer_, libwebm::kMkvCluster))
+  if (WriteID(writer_, adhoc::libwebm::kMkvCluster))
     return false;
 
   // Save for later.
@@ -2730,11 +2730,11 @@ bool Cluster::WriteClusterHeader() {
   if (SerializeInt(writer_, kEbmlUnknownValue, 8))
     return false;
 
-  if (!WriteEbmlElement(writer_, libwebm::kMkvTimecode, timecode(),
+  if (!WriteEbmlElement(writer_, adhoc::libwebm::kMkvTimecode, timecode(),
                         fixed_size_timecode_ ? 8 : 0)) {
     return false;
   }
-  AddPayloadSize(EbmlElementSize(libwebm::kMkvTimecode, timecode(),
+  AddPayloadSize(EbmlElementSize(adhoc::libwebm::kMkvTimecode, timecode(),
                                  fixed_size_timecode_ ? 8 : 0));
   header_written_ = true;
 
@@ -2764,13 +2764,13 @@ bool SeekHead::Finalize(IMkvWriter* writer) const {
 
     for (int32_t i = 0; i < kSeekEntryCount; ++i) {
       if (seek_entry_id_[i] != 0) {
-        entry_size[i] = EbmlElementSize(libwebm::kMkvSeekID,
+        entry_size[i] = EbmlElementSize(adhoc::libwebm::kMkvSeekID,
                                         static_cast<uint64>(seek_entry_id_[i]));
         entry_size[i] += EbmlElementSize(
-            libwebm::kMkvSeekPosition, static_cast<uint64>(seek_entry_pos_[i]));
+            adhoc::libwebm::kMkvSeekPosition, static_cast<uint64>(seek_entry_pos_[i]));
 
         payload_size +=
-            EbmlMasterElementSize(libwebm::kMkvSeek, entry_size[i]) +
+            EbmlMasterElementSize(adhoc::libwebm::kMkvSeek, entry_size[i]) +
             entry_size[i];
       }
     }
@@ -2783,19 +2783,19 @@ bool SeekHead::Finalize(IMkvWriter* writer) const {
     if (writer->Position(start_pos_))
       return false;
 
-    if (!WriteEbmlMasterElement(writer, libwebm::kMkvSeekHead, payload_size))
+    if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvSeekHead, payload_size))
       return false;
 
     for (int32_t i = 0; i < kSeekEntryCount; ++i) {
       if (seek_entry_id_[i] != 0) {
-        if (!WriteEbmlMasterElement(writer, libwebm::kMkvSeek, entry_size[i]))
+        if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvSeek, entry_size[i]))
           return false;
 
-        if (!WriteEbmlElement(writer, libwebm::kMkvSeekID,
+        if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvSeekID,
                               static_cast<uint64>(seek_entry_id_[i])))
           return false;
 
-        if (!WriteEbmlElement(writer, libwebm::kMkvSeekPosition,
+        if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvSeekPosition,
                               static_cast<uint64>(seek_entry_pos_[i])))
           return false;
       }
@@ -2803,7 +2803,7 @@ bool SeekHead::Finalize(IMkvWriter* writer) const {
 
     const uint64_t total_entry_size = kSeekEntryCount * MaxEntrySize();
     const uint64_t total_size =
-        EbmlMasterElementSize(libwebm::kMkvSeekHead, total_entry_size) +
+        EbmlMasterElementSize(adhoc::libwebm::kMkvSeekHead, total_entry_size) +
         total_entry_size;
     const int64_t size_left = total_size - (writer->Position() - start_pos_);
 
@@ -2821,7 +2821,7 @@ bool SeekHead::Finalize(IMkvWriter* writer) const {
 bool SeekHead::Write(IMkvWriter* writer) {
   const uint64_t entry_size = kSeekEntryCount * MaxEntrySize();
   const uint64_t size =
-      EbmlMasterElementSize(libwebm::kMkvSeekHead, entry_size);
+      EbmlMasterElementSize(adhoc::libwebm::kMkvSeekHead, entry_size);
 
   start_pos_ = writer->Position();
 
@@ -2865,12 +2865,12 @@ bool SeekHead::SetSeekEntry(int index, uint32_t id, uint64_t position) {
 
 uint64_t SeekHead::MaxEntrySize() const {
   const uint64_t max_entry_payload_size =
-      EbmlElementSize(libwebm::kMkvSeekID,
+      EbmlElementSize(adhoc::libwebm::kMkvSeekID,
                       static_cast<uint64>(UINT64_C(0xffffffff))) +
-      EbmlElementSize(libwebm::kMkvSeekPosition,
+      EbmlElementSize(adhoc::libwebm::kMkvSeekPosition,
                       static_cast<uint64>(UINT64_C(0xffffffffffffffff)));
   const uint64_t max_entry_size =
-      EbmlMasterElementSize(libwebm::kMkvSeek, max_entry_payload_size) +
+      EbmlMasterElementSize(adhoc::libwebm::kMkvSeek, max_entry_payload_size) +
       max_entry_payload_size;
 
   return max_entry_size;
@@ -2939,7 +2939,7 @@ bool SegmentInfo::Finalize(IMkvWriter* writer) const {
       if (writer->Position(duration_pos_))
         return false;
 
-      if (!WriteEbmlElement(writer, libwebm::kMkvDuration,
+      if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvDuration,
                             static_cast<float>(duration_)))
         return false;
 
@@ -2955,24 +2955,24 @@ bool SegmentInfo::Write(IMkvWriter* writer) {
   if (!writer || !muxing_app_ || !writing_app_)
     return false;
 
-  uint64_t size = EbmlElementSize(libwebm::kMkvTimecodeScale,
+  uint64_t size = EbmlElementSize(adhoc::libwebm::kMkvTimecodeScale,
                                   static_cast<uint64>(timecode_scale_));
   if (duration_ > 0.0)
     size +=
-        EbmlElementSize(libwebm::kMkvDuration, static_cast<float>(duration_));
+        EbmlElementSize(adhoc::libwebm::kMkvDuration, static_cast<float>(duration_));
   if (date_utc_ != INT64_MIN)
-    size += EbmlDateElementSize(libwebm::kMkvDateUTC);
-  size += EbmlElementSize(libwebm::kMkvMuxingApp, muxing_app_);
-  size += EbmlElementSize(libwebm::kMkvWritingApp, writing_app_);
+    size += EbmlDateElementSize(adhoc::libwebm::kMkvDateUTC);
+  size += EbmlElementSize(adhoc::libwebm::kMkvMuxingApp, muxing_app_);
+  size += EbmlElementSize(adhoc::libwebm::kMkvWritingApp, writing_app_);
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvInfo, size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvInfo, size))
     return false;
 
   const int64_t payload_position = writer->Position();
   if (payload_position < 0)
     return false;
 
-  if (!WriteEbmlElement(writer, libwebm::kMkvTimecodeScale,
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvTimecodeScale,
                         static_cast<uint64>(timecode_scale_)))
     return false;
 
@@ -2980,17 +2980,17 @@ bool SegmentInfo::Write(IMkvWriter* writer) {
     // Save for later
     duration_pos_ = writer->Position();
 
-    if (!WriteEbmlElement(writer, libwebm::kMkvDuration,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvDuration,
                           static_cast<float>(duration_)))
       return false;
   }
 
   if (date_utc_ != INT64_MIN)
-    WriteEbmlDateElement(writer, libwebm::kMkvDateUTC, date_utc_);
+    WriteEbmlDateElement(writer, adhoc::libwebm::kMkvDateUTC, date_utc_);
 
-  if (!WriteEbmlElement(writer, libwebm::kMkvMuxingApp, muxing_app_))
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvMuxingApp, muxing_app_))
     return false;
-  if (!WriteEbmlElement(writer, libwebm::kMkvWritingApp, writing_app_))
+  if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvWritingApp, writing_app_))
     return false;
 
   const int64_t stop_position = writer->Position();
@@ -3156,14 +3156,14 @@ void Segment::MoveCuesBeforeClusters() {
   int32_t cluster_index = 0;
   int32_t cues_index = 0;
   for (int32_t i = 0; i < SeekHead::kSeekEntryCount; ++i) {
-    if (seek_head_.GetId(i) == libwebm::kMkvCluster)
+    if (seek_head_.GetId(i) == adhoc::libwebm::kMkvCluster)
       cluster_index = i;
-    if (seek_head_.GetId(i) == libwebm::kMkvCues)
+    if (seek_head_.GetId(i) == adhoc::libwebm::kMkvCues)
       cues_index = i;
   }
-  seek_head_.SetSeekEntry(cues_index, libwebm::kMkvCues,
+  seek_head_.SetSeekEntry(cues_index, adhoc::libwebm::kMkvCues,
                           seek_head_.GetPosition(cluster_index));
-  seek_head_.SetSeekEntry(cluster_index, libwebm::kMkvCluster,
+  seek_head_.SetSeekEntry(cluster_index, adhoc::libwebm::kMkvCluster,
                           cues_.Size() + seek_head_.GetPosition(cues_index));
 }
 
@@ -3181,12 +3181,12 @@ bool Segment::Init(IMkvWriter* ptr_writer) {
   return segment_info_.Init();
 }
 
-bool Segment::CopyAndMoveCuesBeforeClusters(mkvparser::IMkvReader* reader,
+bool Segment::CopyAndMoveCuesBeforeClusters(adhoc::mkvparser::IMkvReader* reader,
                                             IMkvWriter* writer) {
   if (!writer->Seekable() || chunking_)
     return false;
   const int64_t cluster_offset =
-      cluster_list_[0]->size_position() - GetUIntSize(libwebm::kMkvCluster);
+      cluster_list_[0]->size_position() - GetUIntSize(adhoc::libwebm::kMkvCluster);
 
   // Copy the headers.
   if (!ChunkedCopy(reader, writer, 0, cluster_offset))
@@ -3269,7 +3269,7 @@ bool Segment::Finalize() {
       return false;
 
     if (output_cues_)
-      if (!seek_head_.AddSeekEntry(libwebm::kMkvCues, MaxOffset()))
+      if (!seek_head_.AddSeekEntry(adhoc::libwebm::kMkvCues, MaxOffset()))
         return false;
 
     if (chunking_) {
@@ -3698,7 +3698,7 @@ bool Segment::WriteSegmentHeader() {
 
   // Write "unknown" (-1) as segment size value. If mode is kFile, Segment
   // will write over duration when the file is finalized.
-  if (WriteID(writer_header_, libwebm::kMkvSegment))
+  if (WriteID(writer_header_, adhoc::libwebm::kMkvSegment))
     return false;
 
   // Save for later.
@@ -3722,25 +3722,25 @@ bool Segment::WriteSegmentHeader() {
       return false;
   }
 
-  if (!seek_head_.AddSeekEntry(libwebm::kMkvInfo, MaxOffset()))
+  if (!seek_head_.AddSeekEntry(adhoc::libwebm::kMkvInfo, MaxOffset()))
     return false;
   if (!segment_info_.Write(writer_header_))
     return false;
 
-  if (!seek_head_.AddSeekEntry(libwebm::kMkvTracks, MaxOffset()))
+  if (!seek_head_.AddSeekEntry(adhoc::libwebm::kMkvTracks, MaxOffset()))
     return false;
   if (!tracks_.Write(writer_header_))
     return false;
 
   if (chapters_.Count() > 0) {
-    if (!seek_head_.AddSeekEntry(libwebm::kMkvChapters, MaxOffset()))
+    if (!seek_head_.AddSeekEntry(adhoc::libwebm::kMkvChapters, MaxOffset()))
       return false;
     if (!chapters_.Write(writer_header_))
       return false;
   }
 
   if (tags_.Count() > 0) {
-    if (!seek_head_.AddSeekEntry(libwebm::kMkvTags, MaxOffset()))
+    if (!seek_head_.AddSeekEntry(adhoc::libwebm::kMkvTags, MaxOffset()))
       return false;
     if (!tags_.Write(writer_header_))
       return false;
@@ -3945,7 +3945,7 @@ bool Segment::CheckHeaderInfo() {
     if (!WriteSegmentHeader())
       return false;
 
-    if (!seek_head_.AddSeekEntry(libwebm::kMkvCluster, MaxOffset()))
+    if (!seek_head_.AddSeekEntry(adhoc::libwebm::kMkvCluster, MaxOffset()))
       return false;
 
     if (output_cues_ && cues_track_ == 0) {
@@ -4201,4 +4201,4 @@ bool Segment::DocTypeIsWebm() const {
   return true;
 }
 
-}  // namespace mkvmuxer
+}  // namespace adhoc::mkvmuxer

--- a/mkvmuxer/mkvmuxer.h
+++ b/mkvmuxer/mkvmuxer.h
@@ -21,11 +21,10 @@
 // For a description of the WebM elements see
 // http://www.webmproject.org/code/specs/container/.
 
-namespace mkvparser {
+namespace adhoc::mkvparser {
 class IMkvReader;
-}  // namespace mkvparser
-
-namespace mkvmuxer {
+}  // namespace adhoc::mkvparser
+namespace adhoc::mkvmuxer {
 
 class MkvWriter;
 class Segment;
@@ -79,7 +78,7 @@ bool WriteEbmlHeader(IMkvWriter* writer, uint64_t doc_type_version);
 bool WriteEbmlHeader(IMkvWriter* writer);
 
 // Copies in Chunk from source to destination between the given byte positions
-bool ChunkedCopy(mkvparser::IMkvReader* source, IMkvWriter* dst, int64_t start,
+bool ChunkedCopy(adhoc::mkvparser::IMkvReader* source, IMkvWriter* dst, int64_t start,
                  int64_t size);
 
 ///////////////////////////////////////////////////////////////
@@ -364,11 +363,11 @@ class PrimaryChromaticity {
   ~PrimaryChromaticity() {}
 
   // Returns sum of |x_id| and |y_id| element id sizes and payload sizes.
-  uint64_t PrimaryChromaticitySize(libwebm::MkvId x_id,
-                                   libwebm::MkvId y_id) const;
+  uint64_t PrimaryChromaticitySize(adhoc::libwebm::MkvId x_id,
+                                   adhoc::libwebm::MkvId y_id) const;
   bool Valid() const;
-  bool Write(IMkvWriter* writer, libwebm::MkvId x_id,
-             libwebm::MkvId y_id) const;
+  bool Write(IMkvWriter* writer, adhoc::libwebm::MkvId x_id,
+             adhoc::libwebm::MkvId y_id) const;
 
   float x() const { return x_; }
   void set_x(float new_x) { x_ = new_x; }
@@ -1630,7 +1629,7 @@ class Segment {
   // writer - an IMkvWriter object pointing to a *different* file than the one
   //          pointed by the current writer object. This file will contain the
   //          Cues element before the Clusters.
-  bool CopyAndMoveCuesBeforeClusters(mkvparser::IMkvReader* reader,
+  bool CopyAndMoveCuesBeforeClusters(adhoc::mkvparser::IMkvReader* reader,
                                      IMkvWriter* writer);
 
   // Sets which track to use for the Cues element. Must have added the track
@@ -1919,6 +1918,5 @@ class Segment {
   LIBWEBM_DISALLOW_COPY_AND_ASSIGN(Segment);
 };
 
-}  // namespace mkvmuxer
-
+}  // namespace adhoc::mkvmuxer
 #endif  // MKVMUXER_MKVMUXER_H_

--- a/mkvmuxer/mkvmuxertypes.h
+++ b/mkvmuxer/mkvmuxertypes.h
@@ -9,15 +9,14 @@
 #ifndef MKVMUXER_MKVMUXERTYPES_H_
 #define MKVMUXER_MKVMUXERTYPES_H_
 
-namespace mkvmuxer {
+namespace adhoc::mkvmuxer {
 typedef unsigned char uint8;
 typedef short int16;
 typedef int int32;
 typedef unsigned int uint32;
 typedef long long int64;
 typedef unsigned long long uint64;
-}  // namespace mkvmuxer
-
+}  // namespace adhoc::mkvmuxer
 // Copied from Chromium basictypes.h
 // A macro to disallow the copy constructor and operator= functions
 // This should be used in the private: declarations for a class

--- a/mkvmuxer/mkvmuxerutil.cc
+++ b/mkvmuxer/mkvmuxerutil.cc
@@ -25,7 +25,7 @@
 #include "mkvmuxer/mkvmuxer.h"
 #include "mkvmuxer/mkvwriter.h"
 
-namespace mkvmuxer {
+namespace adhoc::mkvmuxer {
 
 namespace {
 
@@ -42,19 +42,19 @@ uint64 WriteBlock(IMkvWriter* writer, const Frame* const frame, int64 timecode,
   uint64 block_additions_elem_size = 0;
   if (frame->additional()) {
     block_additional_elem_size =
-        EbmlElementSize(libwebm::kMkvBlockAdditional, frame->additional(),
+        EbmlElementSize(adhoc::libwebm::kMkvBlockAdditional, frame->additional(),
                         frame->additional_length());
     block_addid_elem_size = EbmlElementSize(
-        libwebm::kMkvBlockAddID, static_cast<uint64>(frame->add_id()));
+        adhoc::libwebm::kMkvBlockAddID, static_cast<uint64>(frame->add_id()));
 
     block_more_payload_size =
         block_addid_elem_size + block_additional_elem_size;
     block_more_elem_size =
-        EbmlMasterElementSize(libwebm::kMkvBlockMore, block_more_payload_size) +
+        EbmlMasterElementSize(adhoc::libwebm::kMkvBlockMore, block_more_payload_size) +
         block_more_payload_size;
     block_additions_payload_size = block_more_elem_size;
     block_additions_elem_size =
-        EbmlMasterElementSize(libwebm::kMkvBlockAdditions,
+        EbmlMasterElementSize(adhoc::libwebm::kMkvBlockAdditions,
                               block_additions_payload_size) +
         block_additions_payload_size;
   }
@@ -62,7 +62,7 @@ uint64 WriteBlock(IMkvWriter* writer, const Frame* const frame, int64 timecode,
   uint64 discard_padding_elem_size = 0;
   if (frame->discard_padding() != 0) {
     discard_padding_elem_size =
-        EbmlElementSize(libwebm::kMkvDiscardPadding,
+        EbmlElementSize(adhoc::libwebm::kMkvDiscardPadding,
                         static_cast<int64>(frame->discard_padding()));
   }
 
@@ -71,30 +71,30 @@ uint64 WriteBlock(IMkvWriter* writer, const Frame* const frame, int64 timecode,
   uint64 reference_block_elem_size = 0;
   if (!frame->is_key()) {
     reference_block_elem_size =
-        EbmlElementSize(libwebm::kMkvReferenceBlock, reference_block_timestamp);
+        EbmlElementSize(adhoc::libwebm::kMkvReferenceBlock, reference_block_timestamp);
   }
 
   const uint64 duration = frame->duration() / timecode_scale;
   uint64 block_duration_elem_size = 0;
   if (duration > 0)
     block_duration_elem_size =
-        EbmlElementSize(libwebm::kMkvBlockDuration, duration);
+        EbmlElementSize(adhoc::libwebm::kMkvBlockDuration, duration);
 
   const uint64 block_payload_size = 4 + frame->length();
   const uint64 block_elem_size =
-      EbmlMasterElementSize(libwebm::kMkvBlock, block_payload_size) +
+      EbmlMasterElementSize(adhoc::libwebm::kMkvBlock, block_payload_size) +
       block_payload_size;
 
   const uint64 block_group_payload_size =
       block_elem_size + block_additions_elem_size + block_duration_elem_size +
       discard_padding_elem_size + reference_block_elem_size;
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvBlockGroup,
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvBlockGroup,
                               block_group_payload_size)) {
     return 0;
   }
 
-  if (!WriteEbmlMasterElement(writer, libwebm::kMkvBlock, block_payload_size))
+  if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvBlock, block_payload_size))
     return 0;
 
   if (WriteUInt(writer, frame->track_number()))
@@ -111,48 +111,48 @@ uint64 WriteBlock(IMkvWriter* writer, const Frame* const frame, int64 timecode,
     return 0;
 
   if (frame->additional()) {
-    if (!WriteEbmlMasterElement(writer, libwebm::kMkvBlockAdditions,
+    if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvBlockAdditions,
                                 block_additions_payload_size)) {
       return 0;
     }
 
-    if (!WriteEbmlMasterElement(writer, libwebm::kMkvBlockMore,
+    if (!WriteEbmlMasterElement(writer, adhoc::libwebm::kMkvBlockMore,
                                 block_more_payload_size))
       return 0;
 
-    if (!WriteEbmlElement(writer, libwebm::kMkvBlockAddID,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvBlockAddID,
                           static_cast<uint64>(frame->add_id())))
       return 0;
 
-    if (!WriteEbmlElement(writer, libwebm::kMkvBlockAdditional,
+    if (!WriteEbmlElement(writer, adhoc::libwebm::kMkvBlockAdditional,
                           frame->additional(), frame->additional_length())) {
       return 0;
     }
   }
 
   if (frame->discard_padding() != 0 &&
-      !WriteEbmlElement(writer, libwebm::kMkvDiscardPadding,
+      !WriteEbmlElement(writer, adhoc::libwebm::kMkvDiscardPadding,
                         static_cast<int64>(frame->discard_padding()))) {
     return false;
   }
 
-  if (!frame->is_key() && !WriteEbmlElement(writer, libwebm::kMkvReferenceBlock,
+  if (!frame->is_key() && !WriteEbmlElement(writer, adhoc::libwebm::kMkvReferenceBlock,
                                             reference_block_timestamp)) {
     return false;
   }
 
   if (duration > 0 &&
-      !WriteEbmlElement(writer, libwebm::kMkvBlockDuration, duration)) {
+      !WriteEbmlElement(writer, adhoc::libwebm::kMkvBlockDuration, duration)) {
     return false;
   }
-  return EbmlMasterElementSize(libwebm::kMkvBlockGroup,
+  return EbmlMasterElementSize(adhoc::libwebm::kMkvBlockGroup,
                                block_group_payload_size) +
          block_group_payload_size;
 }
 
 uint64 WriteSimpleBlock(IMkvWriter* writer, const Frame* const frame,
                         int64 timecode) {
-  if (WriteID(writer, libwebm::kMkvSimpleBlock))
+  if (WriteID(writer, adhoc::libwebm::kMkvSimpleBlock))
     return 0;
 
   const int32 size = static_cast<int32>(frame->length()) + 4;
@@ -175,7 +175,7 @@ uint64 WriteSimpleBlock(IMkvWriter* writer, const Frame* const frame,
   if (writer->Write(frame->frame(), static_cast<uint32>(frame->length())))
     return 0;
 
-  return GetUIntSize(libwebm::kMkvSimpleBlock) + GetCodedUIntSize(size) + 4 +
+  return GetUIntSize(adhoc::libwebm::kMkvSimpleBlock) + GetCodedUIntSize(size) + 4 +
          frame->length();
 }
 
@@ -574,7 +574,7 @@ uint64 WriteVoidElement(IMkvWriter* writer, uint64 size) {
 
   // Subtract one for the void ID and the coded size.
   uint64 void_entry_size = size - 1 - GetCodedUIntSize(size - 1);
-  uint64 void_size = EbmlMasterElementSize(libwebm::kMkvVoid, void_entry_size) +
+  uint64 void_size = EbmlMasterElementSize(adhoc::libwebm::kMkvVoid, void_entry_size) +
                      void_entry_size;
 
   if (void_size != size)
@@ -584,7 +584,7 @@ uint64 WriteVoidElement(IMkvWriter* writer, uint64 size) {
   if (payload_position < 0)
     return 0;
 
-  if (WriteID(writer, libwebm::kMkvVoid))
+  if (WriteID(writer, adhoc::libwebm::kMkvVoid))
     return 0;
 
   if (WriteUInt(writer, void_entry_size))
@@ -649,17 +649,17 @@ uint64 MakeUID(unsigned int* seed) {
 
 bool IsMatrixCoefficientsValueValid(uint64_t value) {
   switch (value) {
-    case mkvmuxer::Colour::kGbr:
-    case mkvmuxer::Colour::kBt709:
-    case mkvmuxer::Colour::kUnspecifiedMc:
-    case mkvmuxer::Colour::kReserved:
-    case mkvmuxer::Colour::kFcc:
-    case mkvmuxer::Colour::kBt470bg:
-    case mkvmuxer::Colour::kSmpte170MMc:
-    case mkvmuxer::Colour::kSmpte240MMc:
-    case mkvmuxer::Colour::kYcocg:
-    case mkvmuxer::Colour::kBt2020NonConstantLuminance:
-    case mkvmuxer::Colour::kBt2020ConstantLuminance:
+    case adhoc::mkvmuxer::Colour::kGbr:
+    case adhoc::mkvmuxer::Colour::kBt709:
+    case adhoc::mkvmuxer::Colour::kUnspecifiedMc:
+    case adhoc::mkvmuxer::Colour::kReserved:
+    case adhoc::mkvmuxer::Colour::kFcc:
+    case adhoc::mkvmuxer::Colour::kBt470bg:
+    case adhoc::mkvmuxer::Colour::kSmpte170MMc:
+    case adhoc::mkvmuxer::Colour::kSmpte240MMc:
+    case adhoc::mkvmuxer::Colour::kYcocg:
+    case adhoc::mkvmuxer::Colour::kBt2020NonConstantLuminance:
+    case adhoc::mkvmuxer::Colour::kBt2020ConstantLuminance:
       return true;
   }
   return false;
@@ -667,9 +667,9 @@ bool IsMatrixCoefficientsValueValid(uint64_t value) {
 
 bool IsChromaSitingHorzValueValid(uint64_t value) {
   switch (value) {
-    case mkvmuxer::Colour::kUnspecifiedCsh:
-    case mkvmuxer::Colour::kLeftCollocated:
-    case mkvmuxer::Colour::kHalfCsh:
+    case adhoc::mkvmuxer::Colour::kUnspecifiedCsh:
+    case adhoc::mkvmuxer::Colour::kLeftCollocated:
+    case adhoc::mkvmuxer::Colour::kHalfCsh:
       return true;
   }
   return false;
@@ -677,9 +677,9 @@ bool IsChromaSitingHorzValueValid(uint64_t value) {
 
 bool IsChromaSitingVertValueValid(uint64_t value) {
   switch (value) {
-    case mkvmuxer::Colour::kUnspecifiedCsv:
-    case mkvmuxer::Colour::kTopCollocated:
-    case mkvmuxer::Colour::kHalfCsv:
+    case adhoc::mkvmuxer::Colour::kUnspecifiedCsv:
+    case adhoc::mkvmuxer::Colour::kTopCollocated:
+    case adhoc::mkvmuxer::Colour::kHalfCsv:
       return true;
   }
   return false;
@@ -687,10 +687,10 @@ bool IsChromaSitingVertValueValid(uint64_t value) {
 
 bool IsColourRangeValueValid(uint64_t value) {
   switch (value) {
-    case mkvmuxer::Colour::kUnspecifiedCr:
-    case mkvmuxer::Colour::kBroadcastRange:
-    case mkvmuxer::Colour::kFullRange:
-    case mkvmuxer::Colour::kMcTcDefined:
+    case adhoc::mkvmuxer::Colour::kUnspecifiedCr:
+    case adhoc::mkvmuxer::Colour::kBroadcastRange:
+    case adhoc::mkvmuxer::Colour::kFullRange:
+    case adhoc::mkvmuxer::Colour::kMcTcDefined:
       return true;
   }
   return false;
@@ -698,24 +698,24 @@ bool IsColourRangeValueValid(uint64_t value) {
 
 bool IsTransferCharacteristicsValueValid(uint64_t value) {
   switch (value) {
-    case mkvmuxer::Colour::kIturBt709Tc:
-    case mkvmuxer::Colour::kUnspecifiedTc:
-    case mkvmuxer::Colour::kReservedTc:
-    case mkvmuxer::Colour::kGamma22Curve:
-    case mkvmuxer::Colour::kGamma28Curve:
-    case mkvmuxer::Colour::kSmpte170MTc:
-    case mkvmuxer::Colour::kSmpte240MTc:
-    case mkvmuxer::Colour::kLinear:
-    case mkvmuxer::Colour::kLog:
-    case mkvmuxer::Colour::kLogSqrt:
-    case mkvmuxer::Colour::kIec6196624:
-    case mkvmuxer::Colour::kIturBt1361ExtendedColourGamut:
-    case mkvmuxer::Colour::kIec6196621:
-    case mkvmuxer::Colour::kIturBt202010bit:
-    case mkvmuxer::Colour::kIturBt202012bit:
-    case mkvmuxer::Colour::kSmpteSt2084:
-    case mkvmuxer::Colour::kSmpteSt4281Tc:
-    case mkvmuxer::Colour::kAribStdB67Hlg:
+    case adhoc::mkvmuxer::Colour::kIturBt709Tc:
+    case adhoc::mkvmuxer::Colour::kUnspecifiedTc:
+    case adhoc::mkvmuxer::Colour::kReservedTc:
+    case adhoc::mkvmuxer::Colour::kGamma22Curve:
+    case adhoc::mkvmuxer::Colour::kGamma28Curve:
+    case adhoc::mkvmuxer::Colour::kSmpte170MTc:
+    case adhoc::mkvmuxer::Colour::kSmpte240MTc:
+    case adhoc::mkvmuxer::Colour::kLinear:
+    case adhoc::mkvmuxer::Colour::kLog:
+    case adhoc::mkvmuxer::Colour::kLogSqrt:
+    case adhoc::mkvmuxer::Colour::kIec6196624:
+    case adhoc::mkvmuxer::Colour::kIturBt1361ExtendedColourGamut:
+    case adhoc::mkvmuxer::Colour::kIec6196621:
+    case adhoc::mkvmuxer::Colour::kIturBt202010bit:
+    case adhoc::mkvmuxer::Colour::kIturBt202012bit:
+    case adhoc::mkvmuxer::Colour::kSmpteSt2084:
+    case adhoc::mkvmuxer::Colour::kSmpteSt4281Tc:
+    case adhoc::mkvmuxer::Colour::kAribStdB67Hlg:
       return true;
   }
   return false;
@@ -723,21 +723,21 @@ bool IsTransferCharacteristicsValueValid(uint64_t value) {
 
 bool IsPrimariesValueValid(uint64_t value) {
   switch (value) {
-    case mkvmuxer::Colour::kReservedP0:
-    case mkvmuxer::Colour::kIturBt709P:
-    case mkvmuxer::Colour::kUnspecifiedP:
-    case mkvmuxer::Colour::kReservedP3:
-    case mkvmuxer::Colour::kIturBt470M:
-    case mkvmuxer::Colour::kIturBt470Bg:
-    case mkvmuxer::Colour::kSmpte170MP:
-    case mkvmuxer::Colour::kSmpte240MP:
-    case mkvmuxer::Colour::kFilm:
-    case mkvmuxer::Colour::kIturBt2020:
-    case mkvmuxer::Colour::kSmpteSt4281P:
-    case mkvmuxer::Colour::kJedecP22Phosphors:
+    case adhoc::mkvmuxer::Colour::kReservedP0:
+    case adhoc::mkvmuxer::Colour::kIturBt709P:
+    case adhoc::mkvmuxer::Colour::kUnspecifiedP:
+    case adhoc::mkvmuxer::Colour::kReservedP3:
+    case adhoc::mkvmuxer::Colour::kIturBt470M:
+    case adhoc::mkvmuxer::Colour::kIturBt470Bg:
+    case adhoc::mkvmuxer::Colour::kSmpte170MP:
+    case adhoc::mkvmuxer::Colour::kSmpte240MP:
+    case adhoc::mkvmuxer::Colour::kFilm:
+    case adhoc::mkvmuxer::Colour::kIturBt2020:
+    case adhoc::mkvmuxer::Colour::kSmpteSt4281P:
+    case adhoc::mkvmuxer::Colour::kJedecP22Phosphors:
       return true;
   }
   return false;
 }
 
-}  // namespace mkvmuxer
+}  // namespace adhoc::mkvmuxer

--- a/mkvmuxer/mkvmuxerutil.h
+++ b/mkvmuxer/mkvmuxerutil.h
@@ -12,14 +12,14 @@
 
 #include "stdint.h"
 
-namespace mkvmuxer {
+namespace adhoc::mkvmuxer {
 class Cluster;
 class Frame;
 class IMkvWriter;
 
-// TODO(tomfinegan): mkvmuxer:: integer types continue to be used here because
+// TODO(tomfinegan): adhoc::mkvmuxer:: integer types continue to be used here because
 // changing them causes pain for downstream projects. It would be nice if a
-// solution that allows removal of the mkvmuxer:: integer types while avoiding
+// solution that allows removal of the adhoc::mkvmuxer:: integer types while avoiding
 // pain for downstream users of libwebm. Considering that mkvmuxerutil.{cc,h}
 // are really, for the great majority of cases, EBML size calculation and writer
 // functions, perhaps a more EBML focused utility would be the way to go as a
@@ -110,6 +110,5 @@ bool IsColourRangeValueValid(uint64_t value);
 bool IsTransferCharacteristicsValueValid(uint64_t value);
 bool IsPrimariesValueValid(uint64_t value);
 
-}  // namespace mkvmuxer
-
+}  // namespace adhoc::mkvmuxer
 #endif  // MKVMUXER_MKVMUXERUTIL_H_

--- a/mkvmuxer/mkvwriter.cc
+++ b/mkvmuxer/mkvwriter.cc
@@ -14,7 +14,7 @@
 #include <share.h>  // for _SH_DENYWR
 #endif
 
-namespace mkvmuxer {
+namespace adhoc::mkvmuxer {
 
 MkvWriter::MkvWriter() : file_(NULL), writer_owns_file_(true) {}
 
@@ -89,4 +89,4 @@ bool MkvWriter::Seekable() const { return true; }
 
 void MkvWriter::ElementStartNotify(uint64, int64) {}
 
-}  // namespace mkvmuxer
+}  // namespace adhoc::mkvmuxer

--- a/mkvmuxer/mkvwriter.h
+++ b/mkvmuxer/mkvwriter.h
@@ -14,7 +14,7 @@
 #include "mkvmuxer/mkvmuxer.h"
 #include "mkvmuxer/mkvmuxertypes.h"
 
-namespace mkvmuxer {
+namespace adhoc::mkvmuxer {
 
 // Default implementation of the IMkvWriter interface on Windows.
 class MkvWriter : public IMkvWriter {
@@ -46,6 +46,5 @@ class MkvWriter : public IMkvWriter {
   LIBWEBM_DISALLOW_COPY_AND_ASSIGN(MkvWriter);
 };
 
-}  // namespace mkvmuxer
-
+}  // namespace adhoc::mkvmuxer
 #endif  // MKVMUXER_MKVWRITER_H_

--- a/mkvmuxer_sample.cc
+++ b/mkvmuxer_sample.cc
@@ -159,10 +159,10 @@ int ParseArgWebVTT(char* argv[], int* argv_index, int argc_check,
   return 0;  // not a WebVTT arg
 }
 
-bool CopyVideoProjection(const mkvparser::Projection& parser_projection,
-                         mkvmuxer::Projection* muxer_projection) {
-  typedef mkvmuxer::Projection::ProjectionType MuxerProjType;
-  const int kTypeNotPresent = mkvparser::Projection::kTypeNotPresent;
+bool CopyVideoProjection(const adhoc::mkvparser::Projection& parser_projection,
+                         adhoc::mkvmuxer::Projection* muxer_projection) {
+  typedef adhoc::mkvmuxer::Projection::ProjectionType MuxerProjType;
+  const int kTypeNotPresent = adhoc::mkvparser::Projection::kTypeNotPresent;
   if (parser_projection.type != kTypeNotPresent) {
     muxer_projection->set_type(
         static_cast<MuxerProjType>(parser_projection.type));
@@ -176,7 +176,7 @@ bool CopyVideoProjection(const mkvparser::Projection& parser_projection,
     }
   }
 
-  const float kValueNotPresent = mkvparser::Projection::kValueNotPresent;
+  const float kValueNotPresent = adhoc::mkvparser::Projection::kValueNotPresent;
   if (parser_projection.pose_yaw != kValueNotPresent)
     muxer_projection->set_pose_yaw(parser_projection.pose_yaw);
   if (parser_projection.pose_pitch != kValueNotPresent)
@@ -219,10 +219,10 @@ int main(int argc, char* argv[]) {
   uint64_t pixel_height = 0;
   uint64_t stereo_mode = 0;
   const char* projection_file = 0;
-  int64_t projection_type = mkvparser::Projection::kTypeNotPresent;
-  float projection_pose_roll = mkvparser::Projection::kValueNotPresent;
-  float projection_pose_pitch = mkvparser::Projection::kValueNotPresent;
-  float projection_pose_yaw = mkvparser::Projection::kValueNotPresent;
+  int64_t projection_type = adhoc::mkvparser::Projection::kTypeNotPresent;
+  float projection_pose_roll = adhoc::mkvparser::Projection::kValueNotPresent;
+  float projection_pose_pitch = adhoc::mkvparser::Projection::kValueNotPresent;
+  float projection_pose_yaw = adhoc::mkvparser::Projection::kValueNotPresent;
   int vp9_profile = -1;  // No profile set.
   int vp9_level = -1;  // No level set.
 
@@ -323,7 +323,7 @@ int main(int argc, char* argv[]) {
   }
 
   // Get parser header info
-  mkvparser::MkvReader reader;
+  adhoc::mkvparser::MkvReader reader;
 
   if (reader.Open(input)) {
     printf("\n Filename is invalid or error while opening.\n");
@@ -331,28 +331,28 @@ int main(int argc, char* argv[]) {
   }
 
   long long pos = 0;
-  mkvparser::EBMLHeader ebml_header;
+  adhoc::mkvparser::EBMLHeader ebml_header;
   long long ret = ebml_header.Parse(&reader, pos);
   if (ret) {
     printf("\n EBMLHeader::Parse() failed.");
     return EXIT_FAILURE;
   }
 
-  mkvparser::Segment* parser_segment_;
-  ret = mkvparser::Segment::CreateInstance(&reader, pos, parser_segment_);
+  adhoc::mkvparser::Segment* parser_segment_;
+  ret = adhoc::mkvparser::Segment::CreateInstance(&reader, pos, parser_segment_);
   if (ret) {
     printf("\n Segment::CreateInstance() failed.");
     return EXIT_FAILURE;
   }
 
-  const std::unique_ptr<mkvparser::Segment> parser_segment(parser_segment_);
+  const std::unique_ptr<adhoc::mkvparser::Segment> parser_segment(parser_segment_);
   ret = parser_segment->Load();
   if (ret < 0) {
     printf("\n Segment::Load() failed.");
     return EXIT_FAILURE;
   }
 
-  const mkvparser::SegmentInfo* const segment_info = parser_segment->GetInfo();
+  const adhoc::mkvparser::SegmentInfo* const segment_info = parser_segment->GetInfo();
   if (segment_info == NULL) {
     printf("\n Segment::GetInfo() failed.");
     return EXIT_FAILURE;
@@ -360,17 +360,17 @@ int main(int argc, char* argv[]) {
   const long long timeCodeScale = segment_info->GetTimeCodeScale();
 
   // Set muxer header info
-  mkvmuxer::MkvWriter writer;
+  adhoc::mkvmuxer::MkvWriter writer;
 
   const std::string temp_file =
-      cues_before_clusters ? libwebm::GetTempFileName() : output;
+      cues_before_clusters ? adhoc::libwebm::GetTempFileName() : output;
   if (!writer.Open(temp_file.c_str())) {
     printf("\n Filename is invalid or error while opening.\n");
     return EXIT_FAILURE;
   }
 
   // Set Segment element attributes
-  mkvmuxer::Segment muxer_segment;
+  adhoc::mkvmuxer::Segment muxer_segment;
 
   if (!muxer_segment.Init(&writer)) {
     printf("\n Could not initialize muxer segment!\n");
@@ -381,9 +381,9 @@ int main(int argc, char* argv[]) {
   muxer_segment.UseFixedSizeClusterTimecode(fixed_size_cluster_timecode);
 
   if (live_mode)
-    muxer_segment.set_mode(mkvmuxer::Segment::kLive);
+    muxer_segment.set_mode(adhoc::mkvmuxer::Segment::kLive);
   else
-    muxer_segment.set_mode(mkvmuxer::Segment::kFile);
+    muxer_segment.set_mode(adhoc::mkvmuxer::Segment::kFile);
 
   if (chunking)
     muxer_segment.SetChunking(true, chunk_name);
@@ -395,18 +395,18 @@ int main(int argc, char* argv[]) {
   muxer_segment.OutputCues(output_cues);
 
   // Set SegmentInfo element attributes
-  mkvmuxer::SegmentInfo* const info = muxer_segment.GetSegmentInfo();
+  adhoc::mkvmuxer::SegmentInfo* const info = muxer_segment.GetSegmentInfo();
   info->set_timecode_scale(timeCodeScale);
   info->set_writing_app("mkvmuxer_sample");
 
-  const mkvparser::Tags* const tags = parser_segment->GetTags();
+  const adhoc::mkvparser::Tags* const tags = parser_segment->GetTags();
   if (copy_tags && tags) {
     for (int i = 0; i < tags->GetTagCount(); i++) {
-      const mkvparser::Tags::Tag* const tag = tags->GetTag(i);
-      mkvmuxer::Tag* muxer_tag = muxer_segment.AddTag();
+      const adhoc::mkvparser::Tags::Tag* const tag = tags->GetTag(i);
+      adhoc::mkvmuxer::Tag* muxer_tag = muxer_segment.AddTag();
 
       for (int j = 0; j < tag->GetSimpleTagCount(); j++) {
-        const mkvparser::Tags::SimpleTag* const simple_tag =
+        const adhoc::mkvparser::Tags::SimpleTag* const simple_tag =
             tag->GetSimpleTag(j);
         muxer_tag->add_simple_tag(simple_tag->GetTagName(),
                                   simple_tag->GetTagString());
@@ -415,12 +415,12 @@ int main(int argc, char* argv[]) {
   }
 
   // Set Tracks element attributes
-  const mkvparser::Tracks* const parser_tracks = parser_segment->GetTracks();
+  const adhoc::mkvparser::Tracks* const parser_tracks = parser_segment->GetTracks();
   unsigned long i = 0;
   uint64_t vid_track = 0;  // no track added
   uint64_t aud_track = 0;  // no track added
 
-  using mkvparser::Track;
+  using adhoc::mkvparser::Track;
 
   while (i != parser_tracks->GetTracksCount()) {
     unsigned long track_num = i++;
@@ -439,8 +439,8 @@ int main(int argc, char* argv[]) {
 
     if (track_type == Track::kVideo && output_video) {
       // Get the video track from the parser
-      const mkvparser::VideoTrack* const pVideoTrack =
-          static_cast<const mkvparser::VideoTrack*>(parser_track);
+      const adhoc::mkvparser::VideoTrack* const pVideoTrack =
+          static_cast<const adhoc::mkvparser::VideoTrack*>(parser_track);
       const long long width = pVideoTrack->GetWidth();
       const long long height = pVideoTrack->GetHeight();
 
@@ -453,7 +453,7 @@ int main(int argc, char* argv[]) {
         return EXIT_FAILURE;
       }
 
-      mkvmuxer::VideoTrack* const video = static_cast<mkvmuxer::VideoTrack*>(
+      adhoc::mkvmuxer::VideoTrack* const video = static_cast<adhoc::mkvmuxer::VideoTrack*>(
           muxer_segment.GetTrackByNumber(vid_track));
       if (!video) {
         printf("\n Could not get video track.\n");
@@ -461,41 +461,41 @@ int main(int argc, char* argv[]) {
       }
 
       if (pVideoTrack->GetColour()) {
-        mkvmuxer::Colour muxer_colour;
-        if (!libwebm::CopyColour(*pVideoTrack->GetColour(), &muxer_colour))
+        adhoc::mkvmuxer::Colour muxer_colour;
+        if (!adhoc::libwebm::CopyColour(*pVideoTrack->GetColour(), &muxer_colour))
           return EXIT_FAILURE;
         if (!video->SetColour(muxer_colour))
           return EXIT_FAILURE;
       }
 
       if (pVideoTrack->GetProjection() ||
-          projection_type != mkvparser::Projection::kTypeNotPresent) {
-        mkvmuxer::Projection muxer_projection;
-        const mkvparser::Projection* const parser_projection =
+          projection_type != adhoc::mkvparser::Projection::kTypeNotPresent) {
+        adhoc::mkvmuxer::Projection muxer_projection;
+        const adhoc::mkvparser::Projection* const parser_projection =
             pVideoTrack->GetProjection();
-        typedef mkvmuxer::Projection::ProjectionType MuxerProjType;
+        typedef adhoc::mkvmuxer::Projection::ProjectionType MuxerProjType;
         if (parser_projection &&
             !CopyVideoProjection(*parser_projection, &muxer_projection)) {
           printf("\n Unable to copy video projection.\n");
           return EXIT_FAILURE;
         }
         // Override the values that came from parser if set on command line.
-        if (projection_type != mkvparser::Projection::kTypeNotPresent) {
+        if (projection_type != adhoc::mkvparser::Projection::kTypeNotPresent) {
           muxer_projection.set_type(
               static_cast<MuxerProjType>(projection_type));
-          if (projection_type == mkvparser::Projection::kRectangular &&
+          if (projection_type == adhoc::mkvparser::Projection::kRectangular &&
               projection_file != NULL) {
             printf("\n Rectangular projection must not have private data.\n");
             return EXIT_FAILURE;
-          } else if ((projection_type == mkvparser::Projection::kCubeMap ||
-                      projection_type == mkvparser::Projection::kMesh) &&
+          } else if ((projection_type == adhoc::mkvparser::Projection::kCubeMap ||
+                      projection_type == adhoc::mkvparser::Projection::kMesh) &&
                      projection_file == NULL) {
             printf("\n Mesh or CubeMap projection must have private data.\n");
             return EXIT_FAILURE;
           }
           if (projection_file != NULL) {
             std::string contents;
-            if (!libwebm::GetFileContents(projection_file, &contents) ||
+            if (!adhoc::libwebm::GetFileContents(projection_file, &contents) ||
                 contents.size() == 0) {
               printf("\n Failed to read file \"%s\" or file is empty\n",
                      projection_file);
@@ -510,7 +510,7 @@ int main(int argc, char* argv[]) {
             }
           }
         }
-        const float kValueNotPresent = mkvparser::Projection::kValueNotPresent;
+        const float kValueNotPresent = adhoc::mkvparser::Projection::kValueNotPresent;
         if (projection_pose_yaw != kValueNotPresent)
           muxer_projection.set_pose_yaw(projection_pose_yaw);
         if (projection_pose_pitch != kValueNotPresent)
@@ -547,14 +547,14 @@ int main(int argc, char* argv[]) {
       const unsigned char* const parser_private_data =
           pVideoTrack->GetCodecPrivate(parser_private_size);
 
-      if (!strcmp(video->codec_id(), mkvmuxer::Tracks::kAv1CodecId)) {
+      if (!strcmp(video->codec_id(), adhoc::mkvmuxer::Tracks::kAv1CodecId)) {
         if (parser_private_data == NULL || parser_private_size == 0) {
           printf("AV1 input track has no CodecPrivate. %s is invalid.", input);
           return EXIT_FAILURE;
         }
       }
 
-      if (!strcmp(video->codec_id(), mkvmuxer::Tracks::kVp9CodecId) &&
+      if (!strcmp(video->codec_id(), adhoc::mkvmuxer::Tracks::kVp9CodecId) &&
           (vp9_profile >= 0 || vp9_level >= 0)) {
         const int kMaxVp9PrivateSize = 6;
         unsigned char vp9_private_data[kMaxVp9PrivateSize];
@@ -604,8 +604,8 @@ int main(int argc, char* argv[]) {
       }
     } else if (track_type == Track::kAudio && output_audio) {
       // Get the audio track from the parser
-      const mkvparser::AudioTrack* const pAudioTrack =
-          static_cast<const mkvparser::AudioTrack*>(parser_track);
+      const adhoc::mkvparser::AudioTrack* const pAudioTrack =
+          static_cast<const adhoc::mkvparser::AudioTrack*>(parser_track);
       const long long channels = pAudioTrack->GetChannels();
       const double sample_rate = pAudioTrack->GetSamplingRate();
 
@@ -618,7 +618,7 @@ int main(int argc, char* argv[]) {
         return EXIT_FAILURE;
       }
 
-      mkvmuxer::AudioTrack* const audio = static_cast<mkvmuxer::AudioTrack*>(
+      adhoc::mkvmuxer::AudioTrack* const audio = static_cast<adhoc::mkvmuxer::AudioTrack*>(
           muxer_segment.GetTrackByNumber(aud_track));
       if (!audio) {
         printf("\n Could not get audio track.\n");
@@ -670,7 +670,7 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
 
   // Set Cues element attributes
-  mkvmuxer::Cues* const cues = muxer_segment.GetCues();
+  adhoc::mkvmuxer::Cues* const cues = muxer_segment.GetCues();
   cues->set_output_block_number(output_cues_block_number);
   if (cues_on_video_track && vid_track)
     muxer_segment.CuesTrack(vid_track);
@@ -681,10 +681,10 @@ int main(int argc, char* argv[]) {
   unsigned char* data = NULL;
   long data_len = 0;
 
-  const mkvparser::Cluster* cluster = parser_segment->GetFirst();
+  const adhoc::mkvparser::Cluster* cluster = parser_segment->GetFirst();
 
   while (cluster != NULL && !cluster->EOS()) {
-    const mkvparser::BlockEntry* block_entry;
+    const adhoc::mkvparser::BlockEntry* block_entry;
 
     long status = cluster->GetFirst(block_entry);
 
@@ -694,9 +694,9 @@ int main(int argc, char* argv[]) {
     }
 
     while (block_entry != NULL && !block_entry->EOS()) {
-      const mkvparser::Block* const block = block_entry->GetBlock();
+      const adhoc::mkvparser::Block* const block = block_entry->GetBlock();
       const long long trackNum = block->GetTrackNumber();
-      const mkvparser::Track* const parser_track =
+      const adhoc::mkvparser::Track* const parser_track =
           parser_tracks->GetTrackByNumber(static_cast<unsigned long>(trackNum));
 
       // When |parser_track| is NULL, it means that the track number in the
@@ -719,7 +719,7 @@ int main(int argc, char* argv[]) {
         const int frame_count = block->GetFrameCount();
 
         for (int i = 0; i < frame_count; ++i) {
-          const mkvparser::Block::Frame& frame = block->GetFrame(i);
+          const adhoc::mkvparser::Block::Frame& frame = block->GetFrame(i);
 
           if (frame.len > data_len) {
             delete[] data;
@@ -732,7 +732,7 @@ int main(int argc, char* argv[]) {
           if (frame.Read(&reader, data))
             return EXIT_FAILURE;
 
-          mkvmuxer::Frame muxer_frame;
+          adhoc::mkvmuxer::Frame muxer_frame;
           if (!muxer_frame.Init(data, frame.len))
             return EXIT_FAILURE;
           muxer_frame.set_track_number(track_type == Track::kAudio ? aud_track

--- a/mkvmuxerutil.hpp
+++ b/mkvmuxerutil.hpp
@@ -12,7 +12,7 @@
 // New projects should not include this file: include the file included below.
 #include "mkvmuxer/mkvmuxerutil.h"
 
-using mkvmuxer::EbmlElementSize;
-using mkvmuxer::EbmlMasterElementSize;
+using adhoc::mkvmuxer::EbmlElementSize;
+using adhoc::mkvmuxer::EbmlMasterElementSize;
 
 #endif  // LIBWEBM_MKVMUXERUTIL_HPP_

--- a/mkvparser/mkvparser.cc
+++ b/mkvparser/mkvparser.cc
@@ -22,7 +22,7 @@
 
 #include "common/webmids.h"
 
-namespace mkvparser {
+namespace adhoc::mkvparser {
 const long long kStringElementSizeLimit = 20 * 1000 * 1000;
 const float MasteringMetadata::kValueNotPresent = FLT_MAX;
 const long long Colour::kValueNotPresent = LLONG_MAX;
@@ -281,7 +281,7 @@ long UnserializeFloat(IMkvReader* pReader, long long pos, long long size_,
     result = d;
   }
 
-  if (mkvparser::isinf(result) || mkvparser::isnan(result))
+  if (adhoc::mkvparser::isinf(result) || adhoc::mkvparser::isnan(result))
     return E_FILE_FORMAT_INVALID;
 
   return 0;
@@ -544,7 +544,7 @@ long long EBMLHeader::Parse(IMkvReader* pReader, long long& pos) {
   if (ebml_id == E_BUFFER_NOT_FULL)
     return E_BUFFER_NOT_FULL;
 
-  if (len != 4 || ebml_id != libwebm::kMkvEBML)
+  if (len != 4 || ebml_id != adhoc::libwebm::kMkvEBML)
     return E_FILE_FORMAT_INVALID;
 
   // Move read pos forward to the EBML header size field.
@@ -598,27 +598,27 @@ long long EBMLHeader::Parse(IMkvReader* pReader, long long& pos) {
     if (size == 0)
       return E_FILE_FORMAT_INVALID;
 
-    if (id == libwebm::kMkvEBMLVersion) {
+    if (id == adhoc::libwebm::kMkvEBMLVersion) {
       m_version = UnserializeUInt(pReader, pos, size);
 
       if (m_version <= 0)
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvEBMLReadVersion) {
+    } else if (id == adhoc::libwebm::kMkvEBMLReadVersion) {
       m_readVersion = UnserializeUInt(pReader, pos, size);
 
       if (m_readVersion <= 0)
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvEBMLMaxIDLength) {
+    } else if (id == adhoc::libwebm::kMkvEBMLMaxIDLength) {
       m_maxIdLength = UnserializeUInt(pReader, pos, size);
 
       if (m_maxIdLength <= 0)
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvEBMLMaxSizeLength) {
+    } else if (id == adhoc::libwebm::kMkvEBMLMaxSizeLength) {
       m_maxSizeLength = UnserializeUInt(pReader, pos, size);
 
       if (m_maxSizeLength <= 0)
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvDocType) {
+    } else if (id == adhoc::libwebm::kMkvDocType) {
       if (m_docType)
         return E_FILE_FORMAT_INVALID;
 
@@ -626,12 +626,12 @@ long long EBMLHeader::Parse(IMkvReader* pReader, long long& pos) {
 
       if (status)  // error
         return status;
-    } else if (id == libwebm::kMkvDocTypeVersion) {
+    } else if (id == adhoc::libwebm::kMkvDocTypeVersion) {
       m_docTypeVersion = UnserializeUInt(pReader, pos, size);
 
       if (m_docTypeVersion <= 0)
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvDocTypeReadVersion) {
+    } else if (id == adhoc::libwebm::kMkvDocTypeReadVersion) {
       m_docTypeReadVersion = UnserializeUInt(pReader, pos, size);
 
       if (m_docTypeReadVersion <= 0)
@@ -785,7 +785,7 @@ long long Segment::CreateInstance(IMkvReader* pReader, long long pos,
     // Handle "unknown size" for live streaming of webm files.
     const long long unknown_size = (1LL << (7 * len)) - 1;
 
-    if (id == libwebm::kMkvSegment) {
+    if (id == adhoc::libwebm::kMkvSegment) {
       if (size == unknown_size)
         size = -1;
 
@@ -877,7 +877,7 @@ long long Segment::ParseHeaders() {
     if (id < 0)
       return E_FILE_FORMAT_INVALID;
 
-    if (id == libwebm::kMkvCluster)
+    if (id == adhoc::libwebm::kMkvCluster)
       break;
 
     pos += len;  // consume ID
@@ -929,7 +929,7 @@ long long Segment::ParseHeaders() {
     if ((pos + size) > available)
       return pos + size;
 
-    if (id == libwebm::kMkvInfo) {
+    if (id == adhoc::libwebm::kMkvInfo) {
       if (m_pInfo)
         return E_FILE_FORMAT_INVALID;
 
@@ -943,7 +943,7 @@ long long Segment::ParseHeaders() {
 
       if (status)
         return status;
-    } else if (id == libwebm::kMkvTracks) {
+    } else if (id == adhoc::libwebm::kMkvTracks) {
       if (m_pTracks)
         return E_FILE_FORMAT_INVALID;
 
@@ -957,7 +957,7 @@ long long Segment::ParseHeaders() {
 
       if (status)
         return status;
-    } else if (id == libwebm::kMkvCues) {
+    } else if (id == adhoc::libwebm::kMkvCues) {
       if (m_pCues == NULL) {
         m_pCues = new (std::nothrow)
             Cues(this, pos, size, element_start, element_size);
@@ -965,7 +965,7 @@ long long Segment::ParseHeaders() {
         if (m_pCues == NULL)
           return -1;
       }
-    } else if (id == libwebm::kMkvSeekHead) {
+    } else if (id == adhoc::libwebm::kMkvSeekHead) {
       if (m_pSeekHead == NULL) {
         m_pSeekHead = new (std::nothrow)
             SeekHead(this, pos, size, element_start, element_size);
@@ -978,7 +978,7 @@ long long Segment::ParseHeaders() {
         if (status)
           return status;
       }
-    } else if (id == libwebm::kMkvChapters) {
+    } else if (id == adhoc::libwebm::kMkvChapters) {
       if (m_pChapters == NULL) {
         m_pChapters = new (std::nothrow)
             Chapters(this, pos, size, element_start, element_size);
@@ -991,7 +991,7 @@ long long Segment::ParseHeaders() {
         if (status)
           return status;
       }
-    } else if (id == libwebm::kMkvTags) {
+    } else if (id == adhoc::libwebm::kMkvTags) {
       if (m_pTags == NULL) {
         m_pTags = new (std::nothrow)
             Tags(this, pos, size, element_start, element_size);
@@ -1130,7 +1130,7 @@ long Segment::DoLoadCluster(long long& pos, long& len) {
       return E_FILE_FORMAT_INVALID;
     }
 
-    if (id == libwebm::kMkvCues) {
+    if (id == adhoc::libwebm::kMkvCues) {
       if (size == unknown_size) {
         // Cues element of unknown size: Not supported.
         return E_FILE_FORMAT_INVALID;
@@ -1148,7 +1148,7 @@ long Segment::DoLoadCluster(long long& pos, long& len) {
       continue;
     }
 
-    if (id != libwebm::kMkvCluster) {
+    if (id != adhoc::libwebm::kMkvCluster) {
       // Besides the Segment, Libwebm allows only cluster elements of unknown
       // size. Fail the parse upon encountering a non-cluster element reporting
       // unknown size.
@@ -1513,11 +1513,11 @@ long SeekHead::Parse() {
     if (status < 0)  // error
       return status;
 
-    if (id == libwebm::kMkvSeek) {
+    if (id == adhoc::libwebm::kMkvSeek) {
       ++entry_count;
       if (entry_count > INT_MAX)
         return E_PARSE_FAILED;
-    } else if (id == libwebm::kMkvVoid) {
+    } else if (id == adhoc::libwebm::kMkvVoid) {
       ++void_element_count;
       if (void_element_count > INT_MAX)
         return E_PARSE_FAILED;
@@ -1564,14 +1564,14 @@ long SeekHead::Parse() {
     if (status < 0)  // error
       return status;
 
-    if (id == libwebm::kMkvSeek && entry_count > 0) {
+    if (id == adhoc::libwebm::kMkvSeek && entry_count > 0) {
       if (ParseEntry(pReader, pos, size, pEntry)) {
         Entry& e = *pEntry++;
 
         e.element_start = idpos;
         e.element_size = (pos + size) - idpos;
       }
-    } else if (id == libwebm::kMkvVoid && void_element_count > 0) {
+    } else if (id == adhoc::libwebm::kMkvVoid && void_element_count > 0) {
       VoidElement& e = *pVoidElement++;
 
       e.element_start = idpos;
@@ -1675,7 +1675,7 @@ long Segment::ParseCues(long long off, long long& pos, long& len) {
 
   const long long id = ReadID(m_pReader, idpos, len);
 
-  if (id != libwebm::kMkvCues)
+  if (id != adhoc::libwebm::kMkvCues)
     return E_FILE_FORMAT_INVALID;
 
   pos += len;  // consume ID
@@ -1757,7 +1757,7 @@ bool SeekHead::ParseEntry(IMkvReader* pReader, long long start, long long size_,
   if (seekIdId < 0)
     return false;
 
-  if (seekIdId != libwebm::kMkvSeekID)
+  if (seekIdId != adhoc::libwebm::kMkvSeekID)
     return false;
 
   if ((pos + len) > stop)
@@ -1790,7 +1790,7 @@ bool SeekHead::ParseEntry(IMkvReader* pReader, long long start, long long size_,
 
   const long long seekPosId = ReadID(pReader, pos, len);
 
-  if (seekPosId != libwebm::kMkvSeekPosition)
+  if (seekPosId != adhoc::libwebm::kMkvSeekPosition)
     return false;
 
   if ((pos + len) > stop)
@@ -1900,7 +1900,7 @@ bool Cues::Init() const {
       return false;
     }
 
-    if (id == libwebm::kMkvCuePoint) {
+    if (id == adhoc::libwebm::kMkvCuePoint) {
       if (!PreloadCuePoint(cue_points_size, idpos))
         return false;
     }
@@ -1975,7 +1975,7 @@ bool Cues::LoadCuePoint() const {
     if ((m_pos + size) > stop)
       return false;
 
-    if (id != libwebm::kMkvCuePoint) {
+    if (id != adhoc::libwebm::kMkvCuePoint) {
       m_pos += size;  // consume payload
       if (m_pos > stop)
         return false;
@@ -2286,7 +2286,7 @@ bool CuePoint::Load(IMkvReader* pReader) {
     long len;
 
     const long long id = ReadID(pReader, pos_, len);
-    if (id != libwebm::kMkvCuePoint)
+    if (id != adhoc::libwebm::kMkvCuePoint)
       return false;
 
     pos_ += len;  // consume ID
@@ -2326,10 +2326,10 @@ bool CuePoint::Load(IMkvReader* pReader) {
       return false;
     }
 
-    if (id == libwebm::kMkvCueTime)
+    if (id == adhoc::libwebm::kMkvCueTime)
       m_timecode = UnserializeUInt(pReader, pos, size);
 
-    else if (id == libwebm::kMkvCueTrackPositions) {
+    else if (id == adhoc::libwebm::kMkvCueTrackPositions) {
       ++track_positions_count;
       if (track_positions_count > UINT_MAX)
         return E_PARSE_FAILED;
@@ -2373,7 +2373,7 @@ bool CuePoint::Load(IMkvReader* pReader) {
     pos += len;  // consume Size field
     assert((pos + size) <= stop);
 
-    if (id == libwebm::kMkvCueTrackPositions) {
+    if (id == adhoc::libwebm::kMkvCueTrackPositions) {
       TrackPosition& tp = *p++;
       if (!tp.Parse(pReader, pos, size)) {
         return false;
@@ -2422,11 +2422,11 @@ bool CuePoint::TrackPosition::Parse(IMkvReader* pReader, long long start_,
       return false;
     }
 
-    if (id == libwebm::kMkvCueTrack)
+    if (id == adhoc::libwebm::kMkvCueTrack)
       m_track = UnserializeUInt(pReader, pos, size);
-    else if (id == libwebm::kMkvCueClusterPosition)
+    else if (id == adhoc::libwebm::kMkvCueClusterPosition)
       m_pos = UnserializeUInt(pReader, pos, size);
-    else if (id == libwebm::kMkvCueBlockNumber)
+    else if (id == adhoc::libwebm::kMkvCueBlockNumber)
       m_block = UnserializeUInt(pReader, pos, size);
 
     pos += size;  // consume payload
@@ -2562,7 +2562,7 @@ const Cluster* Segment::GetNext(const Cluster* pCurr) {
       return NULL;
 
     const long long id = ReadID(m_pReader, pos, len);
-    if (id != libwebm::kMkvCluster)
+    if (id != adhoc::libwebm::kMkvCluster)
       return NULL;
 
     pos += len;  // consume ID
@@ -2619,7 +2619,7 @@ const Cluster* Segment::GetNext(const Cluster* pCurr) {
     if (size == 0)  // weird
       continue;
 
-    if (id == libwebm::kMkvCluster) {
+    if (id == adhoc::libwebm::kMkvCluster) {
       const long long off_next_ = idpos - m_start;
 
       long long pos_;
@@ -2769,7 +2769,7 @@ long Segment::ParseNext(const Cluster* pCurr, const Cluster*& pResult,
 
     const long long id = ReadUInt(m_pReader, pos, len);
 
-    if (id != libwebm::kMkvCluster)
+    if (id != adhoc::libwebm::kMkvCluster)
       return -1;
 
     pos += len;  // consume ID
@@ -2934,7 +2934,7 @@ long Segment::DoParseNext(const Cluster*& pResult, long long& pos, long& len) {
       return E_FILE_FORMAT_INVALID;
     }
 
-    if (id == libwebm::kMkvCues) {
+    if (id == adhoc::libwebm::kMkvCues) {
       if (size == unknown_size)
         return E_FILE_FORMAT_INVALID;
 
@@ -2960,7 +2960,7 @@ long Segment::DoParseNext(const Cluster*& pResult, long long& pos, long& len) {
       continue;
     }
 
-    if (id != libwebm::kMkvCluster) {  // not a Cluster ID
+    if (id != adhoc::libwebm::kMkvCluster) {  // not a Cluster ID
       if (size == unknown_size)
         return E_FILE_FORMAT_INVALID;
 
@@ -3098,7 +3098,7 @@ long Segment::DoParseNext(const Cluster*& pResult, long long& pos, long& len) {
       // that we have exhausted the sub-element's inside the cluster
       // whose ID we parsed earlier.
 
-      if (id == libwebm::kMkvCluster || id == libwebm::kMkvCues)
+      if (id == adhoc::libwebm::kMkvCluster || id == adhoc::libwebm::kMkvCues)
         break;
 
       pos += len;  // consume ID (of sub-element)
@@ -3266,7 +3266,7 @@ long Chapters::Parse() {
     if (size == 0)  // weird
       continue;
 
-    if (id == libwebm::kMkvEditionEntry) {
+    if (id == adhoc::libwebm::kMkvEditionEntry) {
       status = ParseEdition(pos, size);
 
       if (status < 0)  // error
@@ -3382,7 +3382,7 @@ long Chapters::Edition::Parse(IMkvReader* pReader, long long pos,
     if (size == 0)
       continue;
 
-    if (id == libwebm::kMkvChapterAtom) {
+    if (id == adhoc::libwebm::kMkvChapterAtom) {
       status = ParseAtom(pReader, pos, size);
 
       if (status < 0)  // error
@@ -3515,17 +3515,17 @@ long Chapters::Atom::Parse(IMkvReader* pReader, long long pos, long long size) {
     if (size == 0)  // 0 length payload, skip.
       continue;
 
-    if (id == libwebm::kMkvChapterDisplay) {
+    if (id == adhoc::libwebm::kMkvChapterDisplay) {
       status = ParseDisplay(pReader, pos, size);
 
       if (status < 0)  // error
         return status;
-    } else if (id == libwebm::kMkvChapterStringUID) {
+    } else if (id == adhoc::libwebm::kMkvChapterStringUID) {
       status = UnserializeString(pReader, pos, size, m_string_uid);
 
       if (status < 0)  // error
         return status;
-    } else if (id == libwebm::kMkvChapterUID) {
+    } else if (id == adhoc::libwebm::kMkvChapterUID) {
       long long val;
       status = UnserializeInt(pReader, pos, size, val);
 
@@ -3533,14 +3533,14 @@ long Chapters::Atom::Parse(IMkvReader* pReader, long long pos, long long size) {
         return status;
 
       m_uid = static_cast<unsigned long long>(val);
-    } else if (id == libwebm::kMkvChapterTimeStart) {
+    } else if (id == adhoc::libwebm::kMkvChapterTimeStart) {
       const long long val = UnserializeUInt(pReader, pos, size);
 
       if (val < 0)  // error
         return static_cast<long>(val);
 
       m_start_timecode = val;
-    } else if (id == libwebm::kMkvChapterTimeEnd) {
+    } else if (id == adhoc::libwebm::kMkvChapterTimeEnd) {
       const long long val = UnserializeUInt(pReader, pos, size);
 
       if (val < 0)  // error
@@ -3668,17 +3668,17 @@ long Chapters::Display::Parse(IMkvReader* pReader, long long pos,
     if (size == 0)  // No payload.
       continue;
 
-    if (id == libwebm::kMkvChapString) {
+    if (id == adhoc::libwebm::kMkvChapString) {
       status = UnserializeString(pReader, pos, size, m_string);
 
       if (status)
         return status;
-    } else if (id == libwebm::kMkvChapLanguage) {
+    } else if (id == adhoc::libwebm::kMkvChapLanguage) {
       status = UnserializeString(pReader, pos, size, m_language);
 
       if (status)
         return status;
-    } else if (id == libwebm::kMkvChapCountry) {
+    } else if (id == adhoc::libwebm::kMkvChapCountry) {
       status = UnserializeString(pReader, pos, size, m_country);
 
       if (status)
@@ -3731,7 +3731,7 @@ long Tags::Parse() {
     if (size == 0)  // 0 length tag, read another
       continue;
 
-    if (id == libwebm::kMkvTag) {
+    if (id == adhoc::libwebm::kMkvTag) {
       status = ParseTag(pos, size);
 
       if (status < 0)
@@ -3847,7 +3847,7 @@ long Tags::Tag::Parse(IMkvReader* pReader, long long pos, long long size) {
     if (size == 0)  // 0 length tag, read another
       continue;
 
-    if (id == libwebm::kMkvSimpleTag) {
+    if (id == adhoc::libwebm::kMkvSimpleTag) {
       status = ParseSimpleTag(pReader, pos, size);
 
       if (status < 0)
@@ -3938,12 +3938,12 @@ long Tags::SimpleTag::Parse(IMkvReader* pReader, long long pos,
     if (size == 0)  // weird
       continue;
 
-    if (id == libwebm::kMkvTagName) {
+    if (id == adhoc::libwebm::kMkvTagName) {
       status = UnserializeString(pReader, pos, size, m_tag_name);
 
       if (status)
         return status;
-    } else if (id == libwebm::kMkvTagString) {
+    } else if (id == adhoc::libwebm::kMkvTagString) {
       status = UnserializeString(pReader, pos, size, m_tag_string);
 
       if (status)
@@ -4003,12 +4003,12 @@ long SegmentInfo::Parse() {
     if (status < 0)  // error
       return status;
 
-    if (id == libwebm::kMkvTimecodeScale) {
+    if (id == adhoc::libwebm::kMkvTimecodeScale) {
       m_timecodeScale = UnserializeUInt(pReader, pos, size);
 
       if (m_timecodeScale <= 0)
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvDuration) {
+    } else if (id == adhoc::libwebm::kMkvDuration) {
       const long status = UnserializeFloat(pReader, pos, size, m_duration);
 
       if (status < 0)
@@ -4016,19 +4016,19 @@ long SegmentInfo::Parse() {
 
       if (m_duration < 0)
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvMuxingApp) {
+    } else if (id == adhoc::libwebm::kMkvMuxingApp) {
       const long status =
           UnserializeString(pReader, pos, size, m_pMuxingAppAsUTF8);
 
       if (status)
         return status;
-    } else if (id == libwebm::kMkvWritingApp) {
+    } else if (id == adhoc::libwebm::kMkvWritingApp) {
       const long status =
           UnserializeString(pReader, pos, size, m_pWritingAppAsUTF8);
 
       if (status)
         return status;
-    } else if (id == libwebm::kMkvTitle) {
+    } else if (id == adhoc::libwebm::kMkvTitle) {
       const long status = UnserializeString(pReader, pos, size, m_pTitleAsUTF8);
 
       if (status)
@@ -4183,7 +4183,7 @@ long ContentEncoding::ParseContentEncAESSettingsEntry(
     if (status < 0)  // error
       return status;
 
-    if (id == libwebm::kMkvAESSettingsCipherMode) {
+    if (id == adhoc::libwebm::kMkvAESSettingsCipherMode) {
       aes->cipher_mode = UnserializeUInt(pReader, pos, size);
       if (aes->cipher_mode != 1)
         return E_FILE_FORMAT_INVALID;
@@ -4214,13 +4214,13 @@ long ContentEncoding::ParseContentEncodingEntry(long long start, long long size,
     if (status < 0)  // error
       return status;
 
-    if (id == libwebm::kMkvContentCompression) {
+    if (id == adhoc::libwebm::kMkvContentCompression) {
       ++compression_count;
       if (compression_count > INT_MAX)
         return E_PARSE_FAILED;
     }
 
-    if (id == libwebm::kMkvContentEncryption) {
+    if (id == adhoc::libwebm::kMkvContentEncryption) {
       ++encryption_count;
       if (encryption_count > INT_MAX)
         return E_PARSE_FAILED;
@@ -4260,15 +4260,15 @@ long ContentEncoding::ParseContentEncodingEntry(long long start, long long size,
     if (status < 0)  // error
       return status;
 
-    if (id == libwebm::kMkvContentEncodingOrder) {
+    if (id == adhoc::libwebm::kMkvContentEncodingOrder) {
       encoding_order_ = UnserializeUInt(pReader, pos, size);
-    } else if (id == libwebm::kMkvContentEncodingScope) {
+    } else if (id == adhoc::libwebm::kMkvContentEncodingScope) {
       encoding_scope_ = UnserializeUInt(pReader, pos, size);
       if (encoding_scope_ < 1)
         return -1;
-    } else if (id == libwebm::kMkvContentEncodingType) {
+    } else if (id == adhoc::libwebm::kMkvContentEncodingType) {
       encoding_type_ = UnserializeUInt(pReader, pos, size);
-    } else if (id == libwebm::kMkvContentCompression) {
+    } else if (id == adhoc::libwebm::kMkvContentCompression) {
       ContentCompression* const compression =
           new (std::nothrow) ContentCompression();
       if (!compression)
@@ -4281,7 +4281,7 @@ long ContentEncoding::ParseContentEncodingEntry(long long start, long long size,
       }
       assert(compression_count > 0);
       *compression_entries_end_++ = compression;
-    } else if (id == libwebm::kMkvContentEncryption) {
+    } else if (id == adhoc::libwebm::kMkvContentEncryption) {
       ContentEncryption* const encryption =
           new (std::nothrow) ContentEncryption();
       if (!encryption)
@@ -4323,13 +4323,13 @@ long ContentEncoding::ParseCompressionEntry(long long start, long long size,
     if (status < 0)  // error
       return status;
 
-    if (id == libwebm::kMkvContentCompAlgo) {
+    if (id == adhoc::libwebm::kMkvContentCompAlgo) {
       long long algo = UnserializeUInt(pReader, pos, size);
       if (algo < 0)
         return E_FILE_FORMAT_INVALID;
       compression->algo = algo;
       valid = true;
-    } else if (id == libwebm::kMkvContentCompSettings) {
+    } else if (id == adhoc::libwebm::kMkvContentCompSettings) {
       if (size <= 0)
         return E_FILE_FORMAT_INVALID;
 
@@ -4382,11 +4382,11 @@ long ContentEncoding::ParseEncryptionEntry(long long start, long long size,
     if (status < 0)  // error
       return status;
 
-    if (id == libwebm::kMkvContentEncAlgo) {
+    if (id == adhoc::libwebm::kMkvContentEncAlgo) {
       encryption->algo = UnserializeUInt(pReader, pos, size);
       if (encryption->algo != 5)
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvContentEncKeyID) {
+    } else if (id == adhoc::libwebm::kMkvContentEncKeyID) {
       delete[] encryption->key_id;
       encryption->key_id = NULL;
       encryption->key_id_len = 0;
@@ -4408,7 +4408,7 @@ long ContentEncoding::ParseEncryptionEntry(long long start, long long size,
 
       encryption->key_id = buf;
       encryption->key_id_len = buflen;
-    } else if (id == libwebm::kMkvContentSignature) {
+    } else if (id == adhoc::libwebm::kMkvContentSignature) {
       delete[] encryption->signature;
       encryption->signature = NULL;
       encryption->signature_len = 0;
@@ -4430,7 +4430,7 @@ long ContentEncoding::ParseEncryptionEntry(long long start, long long size,
 
       encryption->signature = buf;
       encryption->signature_len = buflen;
-    } else if (id == libwebm::kMkvContentSigKeyID) {
+    } else if (id == adhoc::libwebm::kMkvContentSigKeyID) {
       delete[] encryption->sig_key_id;
       encryption->sig_key_id = NULL;
       encryption->sig_key_id_len = 0;
@@ -4452,11 +4452,11 @@ long ContentEncoding::ParseEncryptionEntry(long long start, long long size,
 
       encryption->sig_key_id = buf;
       encryption->sig_key_id_len = buflen;
-    } else if (id == libwebm::kMkvContentSigAlgo) {
+    } else if (id == adhoc::libwebm::kMkvContentSigAlgo) {
       encryption->sig_algo = UnserializeUInt(pReader, pos, size);
-    } else if (id == libwebm::kMkvContentSigHashAlgo) {
+    } else if (id == adhoc::libwebm::kMkvContentSigHashAlgo) {
       encryption->sig_hash_algo = UnserializeUInt(pReader, pos, size);
-    } else if (id == libwebm::kMkvContentEncAESSettings) {
+    } else if (id == adhoc::libwebm::kMkvContentEncAESSettings) {
       const long status = ParseContentEncAESSettingsEntry(
           pos, size, pReader, &encryption->aes_settings);
       if (status)
@@ -4944,7 +4944,7 @@ long Track::ParseContentEncodingsEntry(long long start, long long size) {
       return status;
 
     // pos now designates start of element
-    if (id == libwebm::kMkvContentEncoding) {
+    if (id == adhoc::libwebm::kMkvContentEncoding) {
       ++count;
       if (count > INT_MAX)
         return E_PARSE_FAILED;
@@ -4973,7 +4973,7 @@ long Track::ParseContentEncodingsEntry(long long start, long long size) {
       return status;
 
     // pos now designates start of element
-    if (id == libwebm::kMkvContentEncoding) {
+    if (id == adhoc::libwebm::kMkvContentEncoding) {
       ContentEncoding* const content_encoding =
           new (std::nothrow) ContentEncoding();
       if (!content_encoding)
@@ -5056,7 +5056,7 @@ bool MasteringMetadata::Parse(IMkvReader* reader, long long mm_start,
     if (status < 0)
       return false;
 
-    if (child_id == libwebm::kMkvLuminanceMax) {
+    if (child_id == adhoc::libwebm::kMkvLuminanceMax) {
       double value = 0;
       const long long value_parse_status =
           UnserializeFloat(reader, read_pos, child_size, value);
@@ -5069,7 +5069,7 @@ bool MasteringMetadata::Parse(IMkvReader* reader, long long mm_start,
           mm_ptr->luminance_max > 9999.99) {
         return false;
       }
-    } else if (child_id == libwebm::kMkvLuminanceMin) {
+    } else if (child_id == adhoc::libwebm::kMkvLuminanceMin) {
       double value = 0;
       const long long value_parse_status =
           UnserializeFloat(reader, read_pos, child_size, value);
@@ -5086,24 +5086,24 @@ bool MasteringMetadata::Parse(IMkvReader* reader, long long mm_start,
       bool is_x = false;
       PrimaryChromaticity** chromaticity;
       switch (child_id) {
-        case libwebm::kMkvPrimaryRChromaticityX:
-        case libwebm::kMkvPrimaryRChromaticityY:
-          is_x = child_id == libwebm::kMkvPrimaryRChromaticityX;
+        case adhoc::libwebm::kMkvPrimaryRChromaticityX:
+        case adhoc::libwebm::kMkvPrimaryRChromaticityY:
+          is_x = child_id == adhoc::libwebm::kMkvPrimaryRChromaticityX;
           chromaticity = &mm_ptr->r;
           break;
-        case libwebm::kMkvPrimaryGChromaticityX:
-        case libwebm::kMkvPrimaryGChromaticityY:
-          is_x = child_id == libwebm::kMkvPrimaryGChromaticityX;
+        case adhoc::libwebm::kMkvPrimaryGChromaticityX:
+        case adhoc::libwebm::kMkvPrimaryGChromaticityY:
+          is_x = child_id == adhoc::libwebm::kMkvPrimaryGChromaticityX;
           chromaticity = &mm_ptr->g;
           break;
-        case libwebm::kMkvPrimaryBChromaticityX:
-        case libwebm::kMkvPrimaryBChromaticityY:
-          is_x = child_id == libwebm::kMkvPrimaryBChromaticityX;
+        case adhoc::libwebm::kMkvPrimaryBChromaticityX:
+        case adhoc::libwebm::kMkvPrimaryBChromaticityY:
+          is_x = child_id == adhoc::libwebm::kMkvPrimaryBChromaticityX;
           chromaticity = &mm_ptr->b;
           break;
-        case libwebm::kMkvWhitePointChromaticityX:
-        case libwebm::kMkvWhitePointChromaticityY:
-          is_x = child_id == libwebm::kMkvWhitePointChromaticityX;
+        case adhoc::libwebm::kMkvWhitePointChromaticityX:
+        case adhoc::libwebm::kMkvWhitePointChromaticityY:
+          is_x = child_id == adhoc::libwebm::kMkvWhitePointChromaticityX;
           chromaticity = &mm_ptr->white_point;
           break;
         default:
@@ -5145,68 +5145,68 @@ bool Colour::Parse(IMkvReader* reader, long long colour_start,
     if (status < 0)
       return false;
 
-    if (child_id == libwebm::kMkvMatrixCoefficients) {
+    if (child_id == adhoc::libwebm::kMkvMatrixCoefficients) {
       colour_ptr->matrix_coefficients =
           UnserializeUInt(reader, read_pos, child_size);
       if (colour_ptr->matrix_coefficients < 0)
         return false;
-    } else if (child_id == libwebm::kMkvBitsPerChannel) {
+    } else if (child_id == adhoc::libwebm::kMkvBitsPerChannel) {
       colour_ptr->bits_per_channel =
           UnserializeUInt(reader, read_pos, child_size);
       if (colour_ptr->bits_per_channel < 0)
         return false;
-    } else if (child_id == libwebm::kMkvChromaSubsamplingHorz) {
+    } else if (child_id == adhoc::libwebm::kMkvChromaSubsamplingHorz) {
       colour_ptr->chroma_subsampling_horz =
           UnserializeUInt(reader, read_pos, child_size);
       if (colour_ptr->chroma_subsampling_horz < 0)
         return false;
-    } else if (child_id == libwebm::kMkvChromaSubsamplingVert) {
+    } else if (child_id == adhoc::libwebm::kMkvChromaSubsamplingVert) {
       colour_ptr->chroma_subsampling_vert =
           UnserializeUInt(reader, read_pos, child_size);
       if (colour_ptr->chroma_subsampling_vert < 0)
         return false;
-    } else if (child_id == libwebm::kMkvCbSubsamplingHorz) {
+    } else if (child_id == adhoc::libwebm::kMkvCbSubsamplingHorz) {
       colour_ptr->cb_subsampling_horz =
           UnserializeUInt(reader, read_pos, child_size);
       if (colour_ptr->cb_subsampling_horz < 0)
         return false;
-    } else if (child_id == libwebm::kMkvCbSubsamplingVert) {
+    } else if (child_id == adhoc::libwebm::kMkvCbSubsamplingVert) {
       colour_ptr->cb_subsampling_vert =
           UnserializeUInt(reader, read_pos, child_size);
       if (colour_ptr->cb_subsampling_vert < 0)
         return false;
-    } else if (child_id == libwebm::kMkvChromaSitingHorz) {
+    } else if (child_id == adhoc::libwebm::kMkvChromaSitingHorz) {
       colour_ptr->chroma_siting_horz =
           UnserializeUInt(reader, read_pos, child_size);
       if (colour_ptr->chroma_siting_horz < 0)
         return false;
-    } else if (child_id == libwebm::kMkvChromaSitingVert) {
+    } else if (child_id == adhoc::libwebm::kMkvChromaSitingVert) {
       colour_ptr->chroma_siting_vert =
           UnserializeUInt(reader, read_pos, child_size);
       if (colour_ptr->chroma_siting_vert < 0)
         return false;
-    } else if (child_id == libwebm::kMkvRange) {
+    } else if (child_id == adhoc::libwebm::kMkvRange) {
       colour_ptr->range = UnserializeUInt(reader, read_pos, child_size);
       if (colour_ptr->range < 0)
         return false;
-    } else if (child_id == libwebm::kMkvTransferCharacteristics) {
+    } else if (child_id == adhoc::libwebm::kMkvTransferCharacteristics) {
       colour_ptr->transfer_characteristics =
           UnserializeUInt(reader, read_pos, child_size);
       if (colour_ptr->transfer_characteristics < 0)
         return false;
-    } else if (child_id == libwebm::kMkvPrimaries) {
+    } else if (child_id == adhoc::libwebm::kMkvPrimaries) {
       colour_ptr->primaries = UnserializeUInt(reader, read_pos, child_size);
       if (colour_ptr->primaries < 0)
         return false;
-    } else if (child_id == libwebm::kMkvMaxCLL) {
+    } else if (child_id == adhoc::libwebm::kMkvMaxCLL) {
       colour_ptr->max_cll = UnserializeUInt(reader, read_pos, child_size);
       if (colour_ptr->max_cll < 0)
         return false;
-    } else if (child_id == libwebm::kMkvMaxFALL) {
+    } else if (child_id == adhoc::libwebm::kMkvMaxFALL) {
       colour_ptr->max_fall = UnserializeUInt(reader, read_pos, child_size);
       if (colour_ptr->max_fall < 0)
         return false;
-    } else if (child_id == libwebm::kMkvMasteringMetadata) {
+    } else if (child_id == adhoc::libwebm::kMkvMasteringMetadata) {
       if (!MasteringMetadata::Parse(reader, read_pos, child_size,
                                     &colour_ptr->mastering_metadata))
         return false;
@@ -5243,14 +5243,14 @@ bool Projection::Parse(IMkvReader* reader, long long start, long long size,
     if (status < 0)
       return false;
 
-    if (child_id == libwebm::kMkvProjectionType) {
+    if (child_id == adhoc::libwebm::kMkvProjectionType) {
       long long projection_type = kTypeNotPresent;
       projection_type = UnserializeUInt(reader, read_pos, child_size);
       if (projection_type < 0)
         return false;
 
       projection_ptr->type = static_cast<ProjectionType>(projection_type);
-    } else if (child_id == libwebm::kMkvProjectionPrivate) {
+    } else if (child_id == adhoc::libwebm::kMkvProjectionPrivate) {
       if (projection_ptr->private_data != NULL)
         return false;
       unsigned char* data = SafeArrayAlloc<unsigned char>(1, child_size);
@@ -5279,13 +5279,13 @@ bool Projection::Parse(IMkvReader* reader, long long start, long long size,
       }
 
       switch (child_id) {
-        case libwebm::kMkvProjectionPoseYaw:
+        case adhoc::libwebm::kMkvProjectionPoseYaw:
           projection_ptr->pose_yaw = static_cast<float>(value);
           break;
-        case libwebm::kMkvProjectionPosePitch:
+        case adhoc::libwebm::kMkvProjectionPosePitch:
           projection_ptr->pose_pitch = static_cast<float>(value);
           break;
-        case libwebm::kMkvProjectionPoseRoll:
+        case adhoc::libwebm::kMkvProjectionPoseRoll:
           projection_ptr->pose_roll = static_cast<float>(value);
           break;
         default:
@@ -5356,37 +5356,37 @@ long VideoTrack::Parse(Segment* pSegment, const Info& info,
     if (status < 0)  // error
       return status;
 
-    if (id == libwebm::kMkvPixelWidth) {
+    if (id == adhoc::libwebm::kMkvPixelWidth) {
       width = UnserializeUInt(pReader, pos, size);
 
       if (width <= 0)
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvPixelHeight) {
+    } else if (id == adhoc::libwebm::kMkvPixelHeight) {
       height = UnserializeUInt(pReader, pos, size);
 
       if (height <= 0)
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvDisplayWidth) {
+    } else if (id == adhoc::libwebm::kMkvDisplayWidth) {
       display_width = UnserializeUInt(pReader, pos, size);
 
       if (display_width <= 0)
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvDisplayHeight) {
+    } else if (id == adhoc::libwebm::kMkvDisplayHeight) {
       display_height = UnserializeUInt(pReader, pos, size);
 
       if (display_height <= 0)
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvDisplayUnit) {
+    } else if (id == adhoc::libwebm::kMkvDisplayUnit) {
       display_unit = UnserializeUInt(pReader, pos, size);
 
       if (display_unit < 0)
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvStereoMode) {
+    } else if (id == adhoc::libwebm::kMkvStereoMode) {
       stereo_mode = UnserializeUInt(pReader, pos, size);
 
       if (stereo_mode < 0)
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvFrameRate) {
+    } else if (id == adhoc::libwebm::kMkvFrameRate) {
       const long status = UnserializeFloat(pReader, pos, size, rate);
 
       if (status < 0)
@@ -5394,21 +5394,21 @@ long VideoTrack::Parse(Segment* pSegment, const Info& info,
 
       if (rate <= 0)
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvColour) {
+    } else if (id == adhoc::libwebm::kMkvColour) {
       Colour* colour = NULL;
       if (!Colour::Parse(pReader, pos, size, &colour)) {
         return E_FILE_FORMAT_INVALID;
       } else {
         colour_ptr.reset(colour);
       }
-    } else if (id == libwebm::kMkvProjection) {
+    } else if (id == adhoc::libwebm::kMkvProjection) {
       Projection* projection = NULL;
       if (!Projection::Parse(pReader, pos, size, &projection)) {
         return E_FILE_FORMAT_INVALID;
       } else {
         projection_ptr.reset(projection);
       }
-    } else if (id == libwebm::kMkvColourSpace) {
+    } else if (id == adhoc::libwebm::kMkvColourSpace) {
       char* colour_space = NULL;
       const long status = UnserializeString(pReader, pos, size, colour_space);
       if (status < 0)
@@ -5603,7 +5603,7 @@ long AudioTrack::Parse(Segment* pSegment, const Info& info,
     if (status < 0)  // error
       return status;
 
-    if (id == libwebm::kMkvSamplingFrequency) {
+    if (id == adhoc::libwebm::kMkvSamplingFrequency) {
       status = UnserializeFloat(pReader, pos, size, rate);
 
       if (status < 0)
@@ -5611,12 +5611,12 @@ long AudioTrack::Parse(Segment* pSegment, const Info& info,
 
       if (rate <= 0)
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvChannels) {
+    } else if (id == adhoc::libwebm::kMkvChannels) {
       channels = UnserializeUInt(pReader, pos, size);
 
       if (channels <= 0)
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvBitDepth) {
+    } else if (id == adhoc::libwebm::kMkvBitDepth) {
       bit_depth = UnserializeUInt(pReader, pos, size);
 
       if (bit_depth <= 0)
@@ -5689,7 +5689,7 @@ long Tracks::Parse() {
     if (size == 0)  // weird
       continue;
 
-    if (id == libwebm::kMkvTrackEntry) {
+    if (id == adhoc::libwebm::kMkvTrackEntry) {
       ++count;
       if (count > INT_MAX)
         return E_PARSE_FAILED;
@@ -5734,7 +5734,7 @@ long Tracks::Parse() {
 
     const long long element_size = payload_stop - element_start;
 
-    if (id == libwebm::kMkvTrackEntry) {
+    if (id == adhoc::libwebm::kMkvTrackEntry) {
       Track*& pTrack = *m_trackEntriesEnd;
       pTrack = NULL;
 
@@ -5810,16 +5810,16 @@ long Tracks::ParseTrackEntry(long long track_start, long long track_size,
 
     const long long start = pos;
 
-    if (id == libwebm::kMkvVideo) {
+    if (id == adhoc::libwebm::kMkvVideo) {
       v.start = start;
       v.size = size;
-    } else if (id == libwebm::kMkvAudio) {
+    } else if (id == adhoc::libwebm::kMkvAudio) {
       a.start = start;
       a.size = size;
-    } else if (id == libwebm::kMkvContentEncodings) {
+    } else if (id == adhoc::libwebm::kMkvContentEncodings) {
       e.start = start;
       e.size = size;
-    } else if (id == libwebm::kMkvTrackUID) {
+    } else if (id == adhoc::libwebm::kMkvTrackUID) {
       if (size > 8)
         return E_FILE_FORMAT_INVALID;
 
@@ -5841,49 +5841,49 @@ long Tracks::ParseTrackEntry(long long track_start, long long track_size,
 
         ++pos_;
       }
-    } else if (id == libwebm::kMkvTrackNumber) {
+    } else if (id == adhoc::libwebm::kMkvTrackNumber) {
       const long long num = UnserializeUInt(pReader, pos, size);
 
       if ((num <= 0) || (num > 127))
         return E_FILE_FORMAT_INVALID;
 
       info.number = static_cast<long>(num);
-    } else if (id == libwebm::kMkvTrackType) {
+    } else if (id == adhoc::libwebm::kMkvTrackType) {
       const long long type = UnserializeUInt(pReader, pos, size);
 
       if ((type <= 0) || (type > 254))
         return E_FILE_FORMAT_INVALID;
 
       info.type = static_cast<long>(type);
-    } else if (id == libwebm::kMkvName) {
+    } else if (id == adhoc::libwebm::kMkvName) {
       const long status =
           UnserializeString(pReader, pos, size, info.nameAsUTF8);
 
       if (status)
         return status;
-    } else if (id == libwebm::kMkvLanguage) {
+    } else if (id == adhoc::libwebm::kMkvLanguage) {
       const long status = UnserializeString(pReader, pos, size, info.language);
 
       if (status)
         return status;
-    } else if (id == libwebm::kMkvDefaultDuration) {
+    } else if (id == adhoc::libwebm::kMkvDefaultDuration) {
       const long long duration = UnserializeUInt(pReader, pos, size);
 
       if (duration < 0)
         return E_FILE_FORMAT_INVALID;
 
       info.defaultDuration = static_cast<unsigned long long>(duration);
-    } else if (id == libwebm::kMkvCodecID) {
+    } else if (id == adhoc::libwebm::kMkvCodecID) {
       const long status = UnserializeString(pReader, pos, size, info.codecId);
 
       if (status)
         return status;
-    } else if (id == libwebm::kMkvFlagLacing) {
+    } else if (id == adhoc::libwebm::kMkvFlagLacing) {
       lacing = UnserializeUInt(pReader, pos, size);
 
       if ((lacing < 0) || (lacing > 1))
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvCodecPrivate) {
+    } else if (id == adhoc::libwebm::kMkvCodecPrivate) {
       delete[] info.codecPrivate;
       info.codecPrivate = NULL;
       info.codecPrivateSize = 0;
@@ -5906,15 +5906,15 @@ long Tracks::ParseTrackEntry(long long track_start, long long track_size,
         info.codecPrivate = buf;
         info.codecPrivateSize = buflen;
       }
-    } else if (id == libwebm::kMkvCodecName) {
+    } else if (id == adhoc::libwebm::kMkvCodecName) {
       const long status =
           UnserializeString(pReader, pos, size, info.codecNameAsUTF8);
 
       if (status)
         return status;
-    } else if (id == libwebm::kMkvCodecDelay) {
+    } else if (id == adhoc::libwebm::kMkvCodecDelay) {
       info.codecDelay = UnserializeUInt(pReader, pos, size);
-    } else if (id == libwebm::kMkvSeekPreRoll) {
+    } else if (id == adhoc::libwebm::kMkvSeekPreRoll) {
       info.seekPreRoll = UnserializeUInt(pReader, pos, size);
     }
 
@@ -6097,7 +6097,7 @@ long Cluster::Load(long long& pos, long& len) const {
   if (id_ < 0)  // error
     return static_cast<long>(id_);
 
-  if (id_ != libwebm::kMkvCluster)
+  if (id_ != adhoc::libwebm::kMkvCluster)
     return E_FILE_FORMAT_INVALID;
 
   pos += len;  // consume id
@@ -6179,10 +6179,10 @@ long Cluster::Load(long long& pos, long& len) const {
     // that we have exhausted the sub-element's inside the cluster
     // whose ID we parsed earlier.
 
-    if (id == libwebm::kMkvCluster)
+    if (id == adhoc::libwebm::kMkvCluster)
       break;
 
-    if (id == libwebm::kMkvCues)
+    if (id == adhoc::libwebm::kMkvCues)
       break;
 
     pos += len;  // consume ID field
@@ -6231,7 +6231,7 @@ long Cluster::Load(long long& pos, long& len) const {
     if ((cluster_stop >= 0) && ((pos + size) > cluster_stop))
       return E_FILE_FORMAT_INVALID;
 
-    if (id == libwebm::kMkvTimecode) {
+    if (id == adhoc::libwebm::kMkvTimecode) {
       len = static_cast<long>(size);
 
       if ((pos + size) > avail)
@@ -6246,10 +6246,10 @@ long Cluster::Load(long long& pos, long& len) const {
 
       if (bBlock)
         break;
-    } else if (id == libwebm::kMkvBlockGroup) {
+    } else if (id == adhoc::libwebm::kMkvBlockGroup) {
       bBlock = true;
       break;
-    } else if (id == libwebm::kMkvSimpleBlock) {
+    } else if (id == adhoc::libwebm::kMkvSimpleBlock) {
       bBlock = true;
       break;
     }
@@ -6347,7 +6347,7 @@ long Cluster::Parse(long long& pos, long& len) const {
     // that we have exhausted the sub-element's inside the cluster
     // whose ID we parsed earlier.
 
-    if ((id == libwebm::kMkvCluster) || (id == libwebm::kMkvCues)) {
+    if ((id == adhoc::libwebm::kMkvCluster) || (id == adhoc::libwebm::kMkvCues)) {
       if (m_element_size < 0)
         m_element_size = pos - m_element_start;
 
@@ -6402,7 +6402,7 @@ long Cluster::Parse(long long& pos, long& len) const {
 
     if (cluster_stop >= 0) {
       if (block_stop > cluster_stop) {
-        if (id == libwebm::kMkvBlockGroup || id == libwebm::kMkvSimpleBlock) {
+        if (id == adhoc::libwebm::kMkvBlockGroup || id == adhoc::libwebm::kMkvSimpleBlock) {
           return E_FILE_FORMAT_INVALID;
         }
 
@@ -6420,10 +6420,10 @@ long Cluster::Parse(long long& pos, long& len) const {
 
     Cluster* const this_ = const_cast<Cluster*>(this);
 
-    if (id == libwebm::kMkvBlockGroup)
+    if (id == adhoc::libwebm::kMkvBlockGroup)
       return this_->ParseBlockGroup(size, pos, len);
 
-    if (id == libwebm::kMkvSimpleBlock)
+    if (id == adhoc::libwebm::kMkvSimpleBlock)
       return this_->ParseSimpleBlock(size, pos, len);
 
     pos += size;  // consume payload
@@ -6554,7 +6554,7 @@ long Cluster::ParseSimpleBlock(long long block_size, long long& pos,
     return E_BUFFER_NOT_FULL;
   }
 
-  status = CreateBlock(libwebm::kMkvSimpleBlock, block_start, block_size,
+  status = CreateBlock(adhoc::libwebm::kMkvSimpleBlock, block_start, block_size,
                        0);  // DiscardPadding
 
   if (status != 0)
@@ -6664,14 +6664,14 @@ long Cluster::ParseBlockGroup(long long payload_size, long long& pos,
     if (size == unknown_size)
       return E_FILE_FORMAT_INVALID;
 
-    if (id == libwebm::kMkvDiscardPadding) {
+    if (id == adhoc::libwebm::kMkvDiscardPadding) {
       status = UnserializeInt(pReader, pos, size, discard_padding);
 
       if (status < 0)  // error
         return status;
     }
 
-    if (id != libwebm::kMkvBlock) {
+    if (id != adhoc::libwebm::kMkvBlock) {
       pos += size;  // consume sub-part of block group
 
       if (pos > payload_stop)
@@ -6764,7 +6764,7 @@ long Cluster::ParseBlockGroup(long long payload_size, long long& pos,
   if (pos != payload_stop)
     return E_FILE_FORMAT_INVALID;
 
-  status = CreateBlock(libwebm::kMkvBlockGroup, payload_start, payload_size,
+  status = CreateBlock(adhoc::libwebm::kMkvBlockGroup, payload_start, payload_size,
                        discard_padding);
   if (status != 0)
     return status;
@@ -6774,7 +6774,7 @@ long Cluster::ParseBlockGroup(long long payload_size, long long& pos,
   return 0;  // success
 }
 
-long Cluster::GetEntry(long index, const mkvparser::BlockEntry*& pEntry) const {
+long Cluster::GetEntry(long index, const adhoc::mkvparser::BlockEntry*& pEntry) const {
   assert(m_pos >= m_element_start);
 
   pEntry = NULL;
@@ -6932,7 +6932,7 @@ long Cluster::HasBlockEntries(
     if (id < 0)  // error
       return static_cast<long>(id);
 
-    if (id != libwebm::kMkvCluster)
+    if (id != adhoc::libwebm::kMkvCluster)
       return E_PARSE_FAILED;
 
     pos += len;  // consume Cluster ID field
@@ -7020,10 +7020,10 @@ long Cluster::HasBlockEntries(
     // that we have exhausted the sub-element's inside the cluster
     // whose ID we parsed earlier.
 
-    if (id == libwebm::kMkvCluster)
+    if (id == adhoc::libwebm::kMkvCluster)
       return 0;  // no entries found
 
-    if (id == libwebm::kMkvCues)
+    if (id == adhoc::libwebm::kMkvCues)
       return 0;  // no entries found
 
     pos += len;  // consume id field
@@ -7075,10 +7075,10 @@ long Cluster::HasBlockEntries(
     if ((cluster_stop >= 0) && ((pos + size) > cluster_stop))
       return E_FILE_FORMAT_INVALID;
 
-    if (id == libwebm::kMkvBlockGroup)
+    if (id == adhoc::libwebm::kMkvBlockGroup)
       return 1;  // have at least one entry
 
-    if (id == libwebm::kMkvSimpleBlock)
+    if (id == adhoc::libwebm::kMkvSimpleBlock)
       return 1;  // have at least one entry
 
     pos += size;  // consume payload
@@ -7153,7 +7153,7 @@ long long Cluster::GetLastTime() const {
 long Cluster::CreateBlock(long long id,
                           long long pos,  // absolute pos of payload
                           long long size, long long discard_padding) {
-  if (id != libwebm::kMkvBlockGroup && id != libwebm::kMkvSimpleBlock)
+  if (id != adhoc::libwebm::kMkvBlockGroup && id != adhoc::libwebm::kMkvSimpleBlock)
     return E_PARSE_FAILED;
 
   if (m_entries_count < 0) {  // haven't parsed anything yet
@@ -7193,7 +7193,7 @@ long Cluster::CreateBlock(long long id,
     }
   }
 
-  if (id == libwebm::kMkvBlockGroup)
+  if (id == adhoc::libwebm::kMkvBlockGroup)
     return CreateBlockGroup(pos, size, discard_padding);
   else
     return CreateSimpleBlock(pos, size);
@@ -7238,12 +7238,12 @@ long Cluster::CreateBlockGroup(long long start_offset, long long size,
 
     pos += len;  // consume size
 
-    if (id == libwebm::kMkvBlock) {
+    if (id == adhoc::libwebm::kMkvBlock) {
       if (bpos < 0) {  // Block ID
         bpos = pos;
         bsize = size;
       }
-    } else if (id == libwebm::kMkvBlockDuration) {
+    } else if (id == adhoc::libwebm::kMkvBlockDuration) {
       if (size > 8)
         return E_FILE_FORMAT_INVALID;
 
@@ -7251,7 +7251,7 @@ long Cluster::CreateBlockGroup(long long start_offset, long long size,
 
       if (duration < 0)
         return E_FILE_FORMAT_INVALID;
-    } else if (id == libwebm::kMkvReferenceBlock) {
+    } else if (id == adhoc::libwebm::kMkvReferenceBlock) {
       if (size > 8 || size <= 0)
         return E_FILE_FORMAT_INVALID;
       const long size_ = static_cast<long>(size);
@@ -8098,4 +8098,4 @@ long Block::Frame::Read(IMkvReader* pReader, unsigned char* buf) const {
 
 long long Block::GetDiscardPadding() const { return m_discard_padding; }
 
-}  // namespace mkvparser
+}  // namespace adhoc::mkvparser

--- a/mkvparser/mkvparser.h
+++ b/mkvparser/mkvparser.h
@@ -10,7 +10,7 @@
 
 #include <cstddef>
 
-namespace mkvparser {
+namespace adhoc::mkvparser {
 
 const int E_PARSE_FAILED = -1;
 const int E_FILE_FORMAT_INVALID = -2;
@@ -1011,7 +1011,7 @@ class Cluster {
   long Load(long long& pos, long& size) const;
 
   long Parse(long long& pos, long& size) const;
-  long GetEntry(long index, const mkvparser::BlockEntry*&) const;
+  long GetEntry(long index, const adhoc::mkvparser::BlockEntry*&) const;
 
  protected:
   Cluster(Segment*, long index, long long element_start);
@@ -1135,9 +1135,8 @@ class Segment {
   const BlockEntry* GetBlock(const CuePoint&, const CuePoint::TrackPosition&);
 };
 
-}  // namespace mkvparser
-
-inline long mkvparser::Segment::LoadCluster() {
+}  // namespace adhoc::mkvparser
+inline long adhoc::mkvparser::Segment::LoadCluster() {
   long long pos;
   long size;
 

--- a/mkvparser/mkvreader.cc
+++ b/mkvparser/mkvreader.cc
@@ -11,7 +11,7 @@
 
 #include <cassert>
 
-namespace mkvparser {
+namespace adhoc::mkvparser {
 
 MkvReader::MkvReader() : m_file(NULL), reader_owns_file_(true) {}
 
@@ -132,4 +132,4 @@ int MkvReader::Read(long long offset, long len, unsigned char* buffer) {
   return 0;  // success
 }
 
-}  // namespace mkvparser
+}  // namespace adhoc::mkvparser

--- a/mkvparser/mkvreader.h
+++ b/mkvparser/mkvreader.h
@@ -12,7 +12,7 @@
 
 #include "mkvparser/mkvparser.h"
 
-namespace mkvparser {
+namespace adhoc::mkvparser {
 
 class MkvReader : public IMkvReader {
  public:
@@ -40,6 +40,5 @@ class MkvReader : public IMkvReader {
   bool reader_owns_file_;
 };
 
-}  // namespace mkvparser
-
+}  // namespace adhoc::mkvparser
 #endif  // MKVPARSER_MKVREADER_H_

--- a/mkvparser_sample.cc
+++ b/mkvparser_sample.cc
@@ -39,15 +39,15 @@ const wchar_t* utf8towcs(const char* str) {
   return val;
 }
 
-bool InputHasCues(const mkvparser::Segment* const segment) {
-  const mkvparser::Cues* const cues = segment->GetCues();
+bool InputHasCues(const adhoc::mkvparser::Segment* const segment) {
+  const adhoc::mkvparser::Cues* const cues = segment->GetCues();
   if (cues == NULL)
     return false;
 
   while (!cues->DoneParsing())
     cues->LoadCuePoint();
 
-  const mkvparser::CuePoint* const cue_point = cues->GetFirst();
+  const adhoc::mkvparser::CuePoint* const cue_point = cues->GetFirst();
   if (cue_point == NULL)
     return false;
 
@@ -55,11 +55,11 @@ bool InputHasCues(const mkvparser::Segment* const segment) {
 }
 
 bool MasteringMetadataValuePresent(double value) {
-  return value != mkvparser::MasteringMetadata::kValueNotPresent;
+  return value != adhoc::mkvparser::MasteringMetadata::kValueNotPresent;
 }
 
 bool ColourValuePresent(long long value) {
-  return value != mkvparser::Colour::kValueNotPresent;
+  return value != adhoc::mkvparser::Colour::kValueNotPresent;
 }
 }  // namespace
 
@@ -70,7 +70,7 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  mkvparser::MkvReader reader;
+  adhoc::mkvparser::MkvReader reader;
 
   if (reader.Open(argv[1])) {
     printf("\n Filename is invalid or error while opening.\n");
@@ -79,12 +79,12 @@ int main(int argc, char* argv[]) {
 
   int maj, min, build, rev;
 
-  mkvparser::GetVersion(maj, min, build, rev);
+  adhoc::mkvparser::GetVersion(maj, min, build, rev);
   printf("\t\t libwebm version: %d.%d.%d.%d\n", maj, min, build, rev);
 
   long long pos = 0;
 
-  mkvparser::EBMLHeader ebmlHeader;
+  adhoc::mkvparser::EBMLHeader ebmlHeader;
 
   long long ret = ebmlHeader.Parse(&reader, pos);
   if (ret < 0) {
@@ -99,7 +99,7 @@ int main(int argc, char* argv[]) {
   printf("\t\tDoc Type\t\t: %s\n", ebmlHeader.m_docType);
   printf("\t\tPos\t\t\t: %lld\n", pos);
 
-  typedef mkvparser::Segment seg_t;
+  typedef adhoc::mkvparser::Segment seg_t;
   seg_t* pSegment_;
 
   ret = seg_t::CreateInstance(&reader, pos, pSegment_);
@@ -116,7 +116,7 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  const mkvparser::SegmentInfo* const pSegmentInfo = pSegment->GetInfo();
+  const adhoc::mkvparser::SegmentInfo* const pSegmentInfo = pSegment->GetInfo();
   if (pSegmentInfo == NULL) {
     printf("\n Segment::GetInfo() failed.");
     return EXIT_FAILURE;
@@ -169,7 +169,7 @@ int main(int argc, char* argv[]) {
   // size of segment payload
   printf("\t\tSize(Segment)\t\t: %lld\n", pSegment->m_size);
 
-  const mkvparser::Tracks* pTracks = pSegment->GetTracks();
+  const adhoc::mkvparser::Tracks* pTracks = pSegment->GetTracks();
 
   unsigned long track_num = 0;
   const unsigned long num_tracks = pTracks->GetTracksCount();
@@ -177,7 +177,7 @@ int main(int argc, char* argv[]) {
   printf("\n\t\t\t   Track Info\n");
 
   while (track_num != num_tracks) {
-    const mkvparser::Track* const pTrack =
+    const adhoc::mkvparser::Track* const pTrack =
         pTracks->GetTrackByIndex(track_num++);
 
     if (pTrack == NULL)
@@ -222,9 +222,9 @@ int main(int argc, char* argv[]) {
       delete[] pCodecName;
     }
 
-    if (trackType == mkvparser::Track::kVideo) {
-      const mkvparser::VideoTrack* const pVideoTrack =
-          static_cast<const mkvparser::VideoTrack*>(pTrack);
+    if (trackType == adhoc::mkvparser::Track::kVideo) {
+      const adhoc::mkvparser::VideoTrack* const pVideoTrack =
+          static_cast<const adhoc::mkvparser::VideoTrack*>(pTrack);
 
       const long long width = pVideoTrack->GetWidth();
       printf("\t\tVideo Width\t\t: %lld\n", width);
@@ -235,7 +235,7 @@ int main(int argc, char* argv[]) {
       const double rate = pVideoTrack->GetFrameRate();
       printf("\t\tVideo Rate\t\t: %f\n", rate);
 
-      const mkvparser::Colour* const colour = pVideoTrack->GetColour();
+      const adhoc::mkvparser::Colour* const colour = pVideoTrack->GetColour();
       if (colour) {
         printf("\t\tVideo Colour:\n");
         if (ColourValuePresent(colour->matrix_coefficients))
@@ -271,7 +271,7 @@ int main(int argc, char* argv[]) {
         if (ColourValuePresent(colour->max_fall))
           printf("\t\t\tMaxFALL: %lld\n", colour->max_fall);
         if (colour->mastering_metadata) {
-          const mkvparser::MasteringMetadata* const mm =
+          const adhoc::mkvparser::MasteringMetadata* const mm =
               colour->mastering_metadata;
           printf("\t\t\tMastering Metadata:\n");
           if (MasteringMetadataValuePresent(mm->luminance_max))
@@ -299,29 +299,29 @@ int main(int argc, char* argv[]) {
         }
       }
 
-      const mkvparser::Projection* const projection =
+      const adhoc::mkvparser::Projection* const projection =
           pVideoTrack->GetProjection();
       if (projection) {
         printf("\t\tVideo Projection:\n");
-        if (projection->type != mkvparser::Projection::kTypeNotPresent)
+        if (projection->type != adhoc::mkvparser::Projection::kTypeNotPresent)
           printf("\t\t\tProjectionType: %d\n",
                  static_cast<int>(projection->type));
         if (projection->private_data) {
           printf("\t\t\tProjectionPrivate: %u bytes\n",
                  static_cast<unsigned int>(projection->private_data_length));
         }
-        if (projection->pose_yaw != mkvparser::Projection::kValueNotPresent)
+        if (projection->pose_yaw != adhoc::mkvparser::Projection::kValueNotPresent)
           printf("\t\t\tProjectionPoseYaw: %f\n", projection->pose_yaw);
-        if (projection->pose_pitch != mkvparser::Projection::kValueNotPresent)
+        if (projection->pose_pitch != adhoc::mkvparser::Projection::kValueNotPresent)
           printf("\t\t\tProjectionPosePitch: %f\n", projection->pose_pitch);
-        if (projection->pose_roll != mkvparser::Projection::kValueNotPresent)
+        if (projection->pose_roll != adhoc::mkvparser::Projection::kValueNotPresent)
           printf("\t\t\tProjectionPosePitch: %f\n", projection->pose_roll);
       }
     }
 
-    if (trackType == mkvparser::Track::kAudio) {
-      const mkvparser::AudioTrack* const pAudioTrack =
-          static_cast<const mkvparser::AudioTrack*>(pTrack);
+    if (trackType == adhoc::mkvparser::Track::kAudio) {
+      const adhoc::mkvparser::AudioTrack* const pAudioTrack =
+          static_cast<const adhoc::mkvparser::AudioTrack*>(pTrack);
 
       const long long channels = pAudioTrack->GetChannels();
       printf("\t\tAudio Channels\t\t: %lld\n", channels);
@@ -350,7 +350,7 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  const mkvparser::Cluster* pCluster = pSegment->GetFirst();
+  const adhoc::mkvparser::Cluster* pCluster = pSegment->GetFirst();
 
   while (pCluster != NULL && !pCluster->EOS()) {
     const long long timeCode = pCluster->GetTimeCode();
@@ -359,7 +359,7 @@ int main(int argc, char* argv[]) {
     const long long time_ns = pCluster->GetTime();
     printf("\t\tCluster Time (ns)\t: %lld\n", time_ns);
 
-    const mkvparser::BlockEntry* pBlockEntry;
+    const adhoc::mkvparser::BlockEntry* pBlockEntry;
 
     long status = pCluster->GetFirst(pBlockEntry);
 
@@ -371,10 +371,10 @@ int main(int argc, char* argv[]) {
     }
 
     while (pBlockEntry != NULL && !pBlockEntry->EOS()) {
-      const mkvparser::Block* const pBlock = pBlockEntry->GetBlock();
+      const adhoc::mkvparser::Block* const pBlock = pBlockEntry->GetBlock();
       const long long trackNum = pBlock->GetTrackNumber();
       const unsigned long tn = static_cast<unsigned long>(trackNum);
-      const mkvparser::Track* const pTrack = pTracks->GetTrackByNumber(tn);
+      const adhoc::mkvparser::Track* const pTrack = pTracks->GetTrackByNumber(tn);
 
       if (pTrack == NULL)
         printf("\t\t\tBlock\t\t:UNKNOWN TRACK TYPE\n");
@@ -385,11 +385,11 @@ int main(int argc, char* argv[]) {
         const long long discard_padding = pBlock->GetDiscardPadding();
 
         printf("\t\t\tBlock\t\t:%s,%s,%15lld,%lld\n",
-               (trackType == mkvparser::Track::kVideo) ? "V" : "A",
+               (trackType == adhoc::mkvparser::Track::kVideo) ? "V" : "A",
                pBlock->IsKey() ? "I" : "P", time_ns, discard_padding);
 
         for (int i = 0; i < frameCount; ++i) {
-          const mkvparser::Block::Frame& theFrame = pBlock->GetFrame(i);
+          const adhoc::mkvparser::Block::Frame& theFrame = pBlock->GetFrame(i);
           const long size = theFrame.len;
           const long long offset = theFrame.pos;
           printf("\t\t\t %15ld,%15llx\n", size, offset);
@@ -410,21 +410,21 @@ int main(int argc, char* argv[]) {
 
   if (InputHasCues(pSegment.get())) {
     // Walk them.
-    const mkvparser::Cues* const cues = pSegment->GetCues();
-    const mkvparser::CuePoint* cue = cues->GetFirst();
+    const adhoc::mkvparser::Cues* const cues = pSegment->GetCues();
+    const adhoc::mkvparser::CuePoint* cue = cues->GetFirst();
     int cue_point_num = 1;
 
     printf("\t\tCues\n");
     do {
       for (track_num = 0; track_num < num_tracks; ++track_num) {
-        const mkvparser::Track* const track =
+        const adhoc::mkvparser::Track* const track =
             pTracks->GetTrackByIndex(track_num);
-        const mkvparser::CuePoint::TrackPosition* const track_pos =
+        const adhoc::mkvparser::CuePoint::TrackPosition* const track_pos =
             cue->Find(track);
 
         if (track_pos != NULL) {
           const char track_type =
-              (track->GetType() == mkvparser::Track::kVideo) ? 'V' : 'A';
+              (track->GetType() == adhoc::mkvparser::Track::kVideo) ? 'V' : 'A';
           printf(
               "\t\t\tCue Point %4d Track %3lu(%c) Time %14lld "
               "Block %4lld Pos %8llx\n",
@@ -439,14 +439,14 @@ int main(int argc, char* argv[]) {
     } while (cue != NULL);
   }
 
-  const mkvparser::Tags* const tags = pSegment->GetTags();
+  const adhoc::mkvparser::Tags* const tags = pSegment->GetTags();
   if (tags && tags->GetTagCount() > 0) {
     printf("\t\tTags\n");
     for (int i = 0; i < tags->GetTagCount(); ++i) {
-      const mkvparser::Tags::Tag* const tag = tags->GetTag(i);
+      const adhoc::mkvparser::Tags::Tag* const tag = tags->GetTag(i);
       printf("\t\t\tTag\n");
       for (int j = 0; j < tag->GetSimpleTagCount(); j++) {
-        const mkvparser::Tags::SimpleTag* const simple_tag =
+        const adhoc::mkvparser::Tags::SimpleTag* const simple_tag =
             tag->GetSimpleTag(j);
         printf("\t\t\t\tSimple Tag \"%s\" Value \"%s\"\n",
                simple_tag->GetTagName(), simple_tag->GetTagString());

--- a/sample_muxer_metadata.cc
+++ b/sample_muxer_metadata.cc
@@ -19,7 +19,7 @@
 
 SampleMuxerMetadata::SampleMuxerMetadata() : segment_(NULL) {}
 
-bool SampleMuxerMetadata::Init(mkvmuxer::Segment* segment) {
+bool SampleMuxerMetadata::Init(adhoc::mkvmuxer::Segment* segment) {
   if (segment == NULL || segment_ != NULL)
     return false;
 
@@ -101,7 +101,7 @@ bool SampleMuxerMetadata::ParseChapters(const char* file,
   cue_list_t& cues = *cues_ptr;
   cues.clear();
 
-  libwebvtt::VttReader r;
+  adhoc::libwebvtt::VttReader r;
   int e = r.Open(file);
 
   if (e) {
@@ -109,7 +109,7 @@ bool SampleMuxerMetadata::ParseChapters(const char* file,
     return false;
   }
 
-  libwebvtt::Parser p(&r);
+  adhoc::libwebvtt::Parser p(&r);
   e = p.Init();
 
   if (e < 0) {  // error
@@ -117,7 +117,7 @@ bool SampleMuxerMetadata::ParseChapters(const char* file,
     return false;
   }
 
-  libwebvtt::Time t;
+  adhoc::libwebvtt::Time t;
   t.hours = -1;
 
   for (;;) {
@@ -150,7 +150,7 @@ bool SampleMuxerMetadata::ParseChapters(const char* file,
 bool SampleMuxerMetadata::AddChapter(const cue_t& cue) {
   // TODO(matthewjheaney): support language and country
 
-  mkvmuxer::Chapter* const chapter = segment_->AddChapter();
+  adhoc::mkvmuxer::Chapter* const chapter = segment_->AddChapter();
 
   if (chapter == NULL) {
     printf("Unable to add chapter\n");
@@ -167,7 +167,7 @@ bool SampleMuxerMetadata::AddChapter(const cue_t& cue) {
     }
   }
 
-  typedef libwebvtt::presentation_t time_ms_t;
+  typedef adhoc::libwebvtt::presentation_t time_ms_t;
   const time_ms_t start_time_ms = cue.start_time.presentation();
   const time_ms_t stop_time_ms = cue.stop_time.presentation();
 
@@ -177,7 +177,7 @@ bool SampleMuxerMetadata::AddChapter(const cue_t& cue) {
 
   chapter->set_time(*segment_, start_time_ns, stop_time_ns);
 
-  typedef libwebvtt::Cue::payload_t::const_iterator iter_t;
+  typedef adhoc::libwebvtt::Cue::payload_t::const_iterator iter_t;
   iter_t i = cue.payload.begin();
   const iter_t j = cue.payload.end();
 
@@ -205,7 +205,7 @@ bool SampleMuxerMetadata::AddTrack(Kind kind, uint64_t* track_num) {
   *track_num = 0;
 
   // Track number value 0 means "let muxer choose track number"
-  mkvmuxer::Track* const track = segment_->AddTrack(0);
+  adhoc::mkvmuxer::Track* const track = segment_->AddTrack(0);
 
   if (track == NULL)  // error
     return false;
@@ -251,7 +251,7 @@ bool SampleMuxerMetadata::AddTrack(Kind kind, uint64_t* track_num) {
 
 bool SampleMuxerMetadata::Parse(const char* file, Kind /* kind */,
                                 uint64_t track_num) {
-  libwebvtt::VttReader r;
+  adhoc::libwebvtt::VttReader r;
   int e = r.Open(file);
 
   if (e) {
@@ -259,7 +259,7 @@ bool SampleMuxerMetadata::Parse(const char* file, Kind /* kind */,
     return false;
   }
 
-  libwebvtt::Parser p(&r);
+  adhoc::libwebvtt::Parser p(&r);
 
   e = p.Init();
 
@@ -271,7 +271,7 @@ bool SampleMuxerMetadata::Parse(const char* file, Kind /* kind */,
   SortableCue cue;
   cue.track_num = track_num;
 
-  libwebvtt::Time t;
+  adhoc::libwebvtt::Time t;
   t.hours = -1;
 
   for (;;) {
@@ -328,7 +328,7 @@ void SampleMuxerMetadata::WriteCueSettings(const cue_t::settings_t& settings,
   const iter_t j = settings.end();
 
   for (;;) {
-    const libwebvtt::Setting& setting = *i++;
+    const adhoc::libwebvtt::Setting& setting = *i++;
 
     pf->append(setting.name);
     pf->push_back(':');
@@ -357,7 +357,7 @@ void SampleMuxerMetadata::WriteCuePayload(const cue_t::payload_t& payload,
   }
 }
 
-bool SampleMuxerMetadata::SortableCue::Write(mkvmuxer::Segment* segment) const {
+bool SampleMuxerMetadata::SortableCue::Write(adhoc::mkvmuxer::Segment* segment) const {
   // Cue start time expressed in milliseconds
   const int64_t start_ms = cue.start_time.presentation();
 
@@ -380,7 +380,7 @@ bool SampleMuxerMetadata::SortableCue::Write(mkvmuxer::Segment* segment) const {
   const data_t buf = reinterpret_cast<data_t>(frame.data());
   const uint64_t len = frame.length();
 
-  mkvmuxer::Frame muxer_frame;
+  adhoc::mkvmuxer::Frame muxer_frame;
   if (!muxer_frame.Init(buf, len))
     return 0;
   muxer_frame.set_track_number(track_num);

--- a/sample_muxer_metadata.h
+++ b/sample_muxer_metadata.h
@@ -17,7 +17,7 @@
 
 #include "webvtt/webvttparser.h"
 
-namespace mkvmuxer {
+namespace adhoc::mkvmuxer {
 class Chapter;
 class Frame;
 class Segment;
@@ -32,7 +32,7 @@ class SampleMuxerMetadata {
 
   // Bind this metadata object to the muxer instance.  Returns false
   // if segment equals NULL, or Init has already been called.
-  bool Init(mkvmuxer::Segment* segment);
+  bool Init(adhoc::mkvmuxer::Segment* segment);
 
   // Parse the WebVTT file |filename| having the indicated |kind|, and
   // create a corresponding track (or chapters element) in the
@@ -47,7 +47,7 @@ class SampleMuxerMetadata {
   bool Write(int64_t time_ns);
 
  private:
-  typedef libwebvtt::Cue cue_t;
+  typedef adhoc::libwebvtt::Cue cue_t;
 
   // Used to sort cues as they are loaded.
   struct SortableCue {
@@ -73,7 +73,7 @@ class SampleMuxerMetadata {
 
     // Write this cue as a metablock to |segment|.  Returns false on
     // error.
-    bool Write(mkvmuxer::Segment* segment) const;
+    bool Write(adhoc::mkvmuxer::Segment* segment) const;
 
     uint64_t track_num;
     cue_t cue;
@@ -120,7 +120,7 @@ class SampleMuxerMetadata {
   static void WriteCuePayload(const cue_t::payload_t& payload,
                               std::string* frame);
 
-  mkvmuxer::Segment* segment_;
+  adhoc::mkvmuxer::Segment* segment_;
 
   // Set of cues ordered by time and then by track number.
   cues_set_t cues_set_;

--- a/testing/mkvmuxer_tests.cc
+++ b/testing/mkvmuxer_tests.cc
@@ -24,17 +24,17 @@
 #include "mkvparser/mkvreader.h"
 #include "testing/test_util.h"
 
-using mkvmuxer::AudioTrack;
-using mkvmuxer::Chapter;
-using mkvmuxer::Frame;
-using mkvmuxer::MkvWriter;
-using mkvmuxer::Segment;
-using mkvmuxer::SegmentInfo;
-using mkvmuxer::Tag;
-using mkvmuxer::Track;
-using mkvmuxer::VideoTrack;
+using adhoc::mkvmuxer::AudioTrack;
+using adhoc::mkvmuxer::Chapter;
+using adhoc::mkvmuxer::Frame;
+using adhoc::mkvmuxer::MkvWriter;
+using adhoc::mkvmuxer::Segment;
+using adhoc::mkvmuxer::SegmentInfo;
+using adhoc::mkvmuxer::Tag;
+using adhoc::mkvmuxer::Track;
+using adhoc::mkvmuxer::VideoTrack;
 
-namespace test {
+namespace adhoc::test {
 
 // Base class containing boiler plate stuff.
 class MuxerTest : public testing::Test {
@@ -48,10 +48,10 @@ class MuxerTest : public testing::Test {
   // are fatal, but the ASSERT_* gtest macros cannot be used in a constructor.
   void Init() {
     ASSERT_TRUE(GetTestDataDir().length() > 0);
-    filename_ = libwebm::GetTempFileName();
+    filename_ = adhoc::libwebm::GetTempFileName();
     ASSERT_GT(filename_.length(), 0u);
-    temp_file_ = libwebm::FilePtr(std::fopen(filename_.c_str(), "wb"),
-                                  libwebm::FILEDeleter());
+    temp_file_ = adhoc::libwebm::FilePtr(std::fopen(filename_.c_str(), "wb"),
+                                  adhoc::libwebm::FILEDeleter());
     ASSERT_TRUE(temp_file_.get() != nullptr);
     writer_.reset(new MkvWriter(temp_file_.get()));
     is_writer_open_ = true;
@@ -107,14 +107,14 @@ class MuxerTest : public testing::Test {
  protected:
   virtual void TearDown() {
     remove(filename_.c_str());
-    testing::Test::TearDown();
+    testing::adhoc::test::TearDown();
   }
 
   std::unique_ptr<MkvWriter> writer_;
   bool is_writer_open_ = false;
   Segment segment_;
   std::string filename_;
-  libwebm::FilePtr temp_file_;
+  adhoc::libwebm::FilePtr temp_file_;
   std::uint8_t dummy_data_[kFrameLength];
 };
 
@@ -484,14 +484,14 @@ TEST_F(MuxerTest, CuesBeforeClusters) {
   segment_.Finalize();
   CloseWriter();
 #ifdef _MSC_VER
-  // Close the output file: the MS run time won't allow mkvparser::MkvReader
+  // Close the output file: the MS run time won't allow adhoc::mkvparser::MkvReader
   // to open a file for reading when it's still open for writing.
   temp_file_.reset();
 #endif
-  mkvparser::MkvReader reader;
+  adhoc::mkvparser::MkvReader reader;
   ASSERT_EQ(0, reader.Open(filename_.c_str()));
   MkvWriter cues_writer;
-  std::string cues_filename = libwebm::GetTempFileName();
+  std::string cues_filename = adhoc::libwebm::GetTempFileName();
   ASSERT_GT(cues_filename.length(), 0u);
   cues_writer.Open(cues_filename.c_str());
   EXPECT_TRUE(segment_.CopyAndMoveCuesBeforeClusters(&reader, &cues_writer));
@@ -794,25 +794,25 @@ TEST_F(MuxerTest, Colour) {
   EXPECT_TRUE(SegmentInit(false, false, false));
   AddVideoTrack();
 
-  mkvmuxer::PrimaryChromaticity muxer_pc(.1, .2);
-  mkvmuxer::MasteringMetadata muxer_mm;
+  adhoc::mkvmuxer::PrimaryChromaticity muxer_pc(.1, .2);
+  adhoc::mkvmuxer::MasteringMetadata muxer_mm;
   muxer_mm.set_luminance_min(30.0);
   muxer_mm.set_luminance_max(40.0);
   ASSERT_TRUE(
       muxer_mm.SetChromaticity(&muxer_pc, &muxer_pc, &muxer_pc, &muxer_pc));
 
-  mkvmuxer::Colour muxer_colour;
-  muxer_colour.set_matrix_coefficients(mkvmuxer::Colour::kGbr);
+  adhoc::mkvmuxer::Colour muxer_colour;
+  muxer_colour.set_matrix_coefficients(adhoc::mkvmuxer::Colour::kGbr);
   muxer_colour.set_bits_per_channel(1);
   muxer_colour.set_chroma_subsampling_horz(2);
   muxer_colour.set_chroma_subsampling_vert(3);
   muxer_colour.set_cb_subsampling_horz(4);
   muxer_colour.set_cb_subsampling_vert(5);
-  muxer_colour.set_chroma_siting_horz(mkvmuxer::Colour::kLeftCollocated);
-  muxer_colour.set_chroma_siting_vert(mkvmuxer::Colour::kTopCollocated);
-  muxer_colour.set_range(mkvmuxer::Colour::kFullRange);
-  muxer_colour.set_transfer_characteristics(mkvmuxer::Colour::kLog);
-  muxer_colour.set_primaries(mkvmuxer::Colour::kSmpteSt4281P);
+  muxer_colour.set_chroma_siting_horz(adhoc::mkvmuxer::Colour::kLeftCollocated);
+  muxer_colour.set_chroma_siting_vert(adhoc::mkvmuxer::Colour::kTopCollocated);
+  muxer_colour.set_range(adhoc::mkvmuxer::Colour::kFullRange);
+  muxer_colour.set_transfer_characteristics(adhoc::mkvmuxer::Colour::kLog);
+  muxer_colour.set_primaries(adhoc::mkvmuxer::Colour::kSmpteSt4281P);
   muxer_colour.set_max_cll(11);
   muxer_colour.set_max_fall(12);
   ASSERT_TRUE(muxer_colour.SetMasteringMetadata(muxer_mm));
@@ -826,10 +826,10 @@ TEST_F(MuxerTest, Colour) {
   MkvParser parser;
   ASSERT_TRUE(ParseMkvFileReleaseParser(filename_, &parser));
 
-  const mkvparser::VideoTrack* const parser_track =
-      static_cast<const mkvparser::VideoTrack*>(
+  const adhoc::mkvparser::VideoTrack* const parser_track =
+      static_cast<const adhoc::mkvparser::VideoTrack*>(
           parser.segment->GetTracks()->GetTrackByIndex(0));
-  const mkvparser::Colour* parser_colour = parser_track->GetColour();
+  const adhoc::mkvparser::Colour* parser_colour = parser_track->GetColour();
   ASSERT_TRUE(parser_colour != nullptr);
   EXPECT_EQ(static_cast<long long>(muxer_colour.matrix_coefficients()),
             parser_colour->matrix_coefficients);
@@ -857,7 +857,7 @@ TEST_F(MuxerTest, Colour) {
   EXPECT_EQ(static_cast<long long>(muxer_colour.max_fall()),
             parser_colour->max_fall);
 
-  const mkvparser::MasteringMetadata* const parser_mm =
+  const adhoc::mkvparser::MasteringMetadata* const parser_mm =
       parser_colour->mastering_metadata;
   ASSERT_TRUE(parser_mm != nullptr);
   EXPECT_FLOAT_EQ(muxer_mm.luminance_min(), parser_mm->luminance_min);
@@ -876,9 +876,9 @@ TEST_F(MuxerTest, Colour) {
 TEST_F(MuxerTest, ColourPartial) {
   EXPECT_TRUE(SegmentInit(false, false, false));
   AddVideoTrack();
-  mkvmuxer::Colour muxer_colour;
+  adhoc::mkvmuxer::Colour muxer_colour;
   muxer_colour.set_matrix_coefficients(
-      mkvmuxer::Colour::kBt2020NonConstantLuminance);
+      adhoc::mkvmuxer::Colour::kBt2020NonConstantLuminance);
 
   VideoTrack* const video_track =
       dynamic_cast<VideoTrack*>(segment_.GetTrackByNumber(kVideoTrackNumber));
@@ -889,10 +889,10 @@ TEST_F(MuxerTest, ColourPartial) {
   MkvParser parser;
   ASSERT_TRUE(ParseMkvFileReleaseParser(filename_, &parser));
 
-  const mkvparser::VideoTrack* const parser_track =
-      static_cast<const mkvparser::VideoTrack*>(
+  const adhoc::mkvparser::VideoTrack* const parser_track =
+      static_cast<const adhoc::mkvparser::VideoTrack*>(
           parser.segment->GetTracks()->GetTrackByIndex(0));
-  const mkvparser::Colour* parser_colour = parser_track->GetColour();
+  const adhoc::mkvparser::Colour* parser_colour = parser_track->GetColour();
   EXPECT_EQ(static_cast<long long>(muxer_colour.matrix_coefficients()),
             parser_colour->matrix_coefficients);
 }
@@ -901,8 +901,8 @@ TEST_F(MuxerTest, Projection) {
   EXPECT_TRUE(SegmentInit(false, false, false));
   AddVideoTrack();
 
-  mkvmuxer::Projection muxer_proj;
-  muxer_proj.set_type(mkvmuxer::Projection::kRectangular);
+  adhoc::mkvmuxer::Projection muxer_proj;
+  muxer_proj.set_type(adhoc::mkvmuxer::Projection::kRectangular);
   muxer_proj.set_pose_yaw(1);
   muxer_proj.set_pose_pitch(2);
   muxer_proj.set_pose_roll(3);
@@ -920,11 +920,11 @@ TEST_F(MuxerTest, Projection) {
   MkvParser parser;
   ASSERT_TRUE(ParseMkvFileReleaseParser(filename_, &parser));
 
-  const mkvparser::VideoTrack* const parser_track =
-      static_cast<const mkvparser::VideoTrack*>(
+  const adhoc::mkvparser::VideoTrack* const parser_track =
+      static_cast<const adhoc::mkvparser::VideoTrack*>(
           parser.segment->GetTracks()->GetTrackByIndex(0));
 
-  const mkvparser::Projection* const parser_proj =
+  const adhoc::mkvparser::Projection* const parser_proj =
       parser_track->GetProjection();
   ASSERT_TRUE(parser_proj != nullptr);
   EXPECT_FLOAT_EQ(muxer_proj.pose_yaw(), parser_proj->pose_yaw);
@@ -935,7 +935,7 @@ TEST_F(MuxerTest, Projection) {
             parser_proj->private_data_length);
 
   EXPECT_EQ(muxer_proj.private_data()[0], parser_proj->private_data[0]);
-  typedef mkvparser::Projection::ProjectionType ParserProjType;
+  typedef adhoc::mkvparser::Projection::ProjectionType ParserProjType;
   EXPECT_EQ(static_cast<ParserProjType>(muxer_proj.type()), parser_proj->type);
   EXPECT_TRUE(CompareFiles(GetTestFilePath("projection.webm"), filename_));
 }
@@ -1002,8 +1002,7 @@ TEST_F(MuxerTest, LongTagString) {
   EXPECT_TRUE(CompareFiles(GetTestFilePath("long_tag_string.webm"), filename_));
 }
 
-}  // namespace test
-
+}  // namespace adhoc::test
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/testing/mkvparser_fuzzer.cc
+++ b/testing/mkvparser_fuzzer.cc
@@ -18,7 +18,7 @@
 
 namespace {
 
-class MemoryReader : public mkvparser::IMkvReader {
+class MemoryReader : public adhoc::mkvparser::IMkvReader {
  public:
   MemoryReader(const uint8_t* data, size_t size) : data_(data), size_(size) {}
 
@@ -48,8 +48,8 @@ class MemoryReader : public mkvparser::IMkvReader {
   size_t size_;
 };
 
-void ParseCues(const mkvparser::Segment& segment) {
-  const mkvparser::Cues* const cues = segment.GetCues();
+void ParseCues(const adhoc::mkvparser::Segment& segment) {
+  const adhoc::mkvparser::Cues* const cues = segment.GetCues();
   if (cues == nullptr) {
     return;
   }
@@ -59,60 +59,60 @@ void ParseCues(const mkvparser::Segment& segment) {
   }
 }
 
-const mkvparser::BlockEntry* GetBlockEntryFromCues(
-    const void* ctx, const mkvparser::CuePoint* cue,
-    const mkvparser::CuePoint::TrackPosition* track_pos) {
-  const auto* const cues = static_cast<const mkvparser::Cues*>(ctx);
+const adhoc::mkvparser::BlockEntry* GetBlockEntryFromCues(
+    const void* ctx, const adhoc::mkvparser::CuePoint* cue,
+    const adhoc::mkvparser::CuePoint::TrackPosition* track_pos) {
+  const auto* const cues = static_cast<const adhoc::mkvparser::Cues*>(ctx);
   return cues->GetBlock(cue, track_pos);
 }
 
-const mkvparser::BlockEntry* GetBlockEntryFromCluster(
-    const void* ctx, const mkvparser::CuePoint* cue,
-    const mkvparser::CuePoint::TrackPosition* track_pos) {
+const adhoc::mkvparser::BlockEntry* GetBlockEntryFromCluster(
+    const void* ctx, const adhoc::mkvparser::CuePoint* cue,
+    const adhoc::mkvparser::CuePoint::TrackPosition* track_pos) {
   if (track_pos == nullptr) {
     return nullptr;
   }
-  const auto* const cluster = static_cast<const mkvparser::Cluster*>(ctx);
-  const mkvparser::BlockEntry* block_entry =
+  const auto* const cluster = static_cast<const adhoc::mkvparser::Cluster*>(ctx);
+  const adhoc::mkvparser::BlockEntry* block_entry =
       cluster->GetEntry(*cue, *track_pos);
   return block_entry;
 }
 
-void WalkCues(const mkvparser::Segment& segment,
-              std::function<const mkvparser::BlockEntry*(
-                  const void*, const mkvparser::CuePoint*,
-                  const mkvparser::CuePoint::TrackPosition*)>
+void WalkCues(const adhoc::mkvparser::Segment& segment,
+              std::function<const adhoc::mkvparser::BlockEntry*(
+                  const void*, const adhoc::mkvparser::CuePoint*,
+                  const adhoc::mkvparser::CuePoint::TrackPosition*)>
                   get_block_entry,
               const void* ctx) {
-  const mkvparser::Cues* const cues = segment.GetCues();
-  const mkvparser::Tracks* tracks = segment.GetTracks();
+  const adhoc::mkvparser::Cues* const cues = segment.GetCues();
+  const adhoc::mkvparser::Tracks* tracks = segment.GetTracks();
   if (cues == nullptr || tracks == nullptr) {
     return;
   }
   const unsigned long num_tracks = tracks->GetTracksCount();
 
-  for (const mkvparser::CuePoint* cue = cues->GetFirst(); cue != nullptr;
+  for (const adhoc::mkvparser::CuePoint* cue = cues->GetFirst(); cue != nullptr;
        cue = cues->GetNext(cue)) {
     for (unsigned long track_num = 0; track_num < num_tracks; ++track_num) {
-      const mkvparser::Track* const track = tracks->GetTrackByIndex(track_num);
-      const mkvparser::CuePoint::TrackPosition* const track_pos =
+      const adhoc::mkvparser::Track* const track = tracks->GetTrackByIndex(track_num);
+      const adhoc::mkvparser::CuePoint::TrackPosition* const track_pos =
           cue->Find(track);
-      const mkvparser::BlockEntry* block_entry =
+      const adhoc::mkvparser::BlockEntry* block_entry =
           get_block_entry(ctx, cue, track_pos);
       static_cast<void>(block_entry);
     }
   }
 }
 
-void ParseCluster(const mkvparser::Cluster& cluster) {
-  const mkvparser::BlockEntry* block_entry;
+void ParseCluster(const adhoc::mkvparser::Cluster& cluster) {
+  const adhoc::mkvparser::BlockEntry* block_entry;
   long status = cluster.GetFirst(block_entry);
   if (status != 0) {
     return;
   }
 
   while (block_entry != nullptr && !block_entry->EOS()) {
-    const mkvparser::Block* const block = block_entry->GetBlock();
+    const adhoc::mkvparser::Block* const block = block_entry->GetBlock();
     if (block == nullptr) {
       return;
     }
@@ -130,17 +130,17 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   MemoryReader reader(data, size);
 
   long long int pos = 0;
-  std::unique_ptr<mkvparser::EBMLHeader> ebml_header(
-      new (std::nothrow) mkvparser::EBMLHeader());  // NOLINT
+  std::unique_ptr<adhoc::mkvparser::EBMLHeader> ebml_header(
+      new (std::nothrow) adhoc::mkvparser::EBMLHeader());  // NOLINT
   if (ebml_header->Parse(&reader, pos) < 0) {
     return 0;
   }
 
-  mkvparser::Segment* temp_segment;
-  if (mkvparser::Segment::CreateInstance(&reader, pos, temp_segment) != 0) {
+  adhoc::mkvparser::Segment* temp_segment;
+  if (adhoc::mkvparser::Segment::CreateInstance(&reader, pos, temp_segment) != 0) {
     return 0;
   }
-  std::unique_ptr<mkvparser::Segment> segment(temp_segment);
+  std::unique_ptr<adhoc::mkvparser::Segment> segment(temp_segment);
 
   if (segment->Load() < 0) {
     return 0;
@@ -149,7 +149,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   ParseCues(*segment);
   WalkCues(*segment, GetBlockEntryFromCues, segment->GetCues());
 
-  const mkvparser::Cluster* cluster = segment->GetFirst();
+  const adhoc::mkvparser::Cluster* cluster = segment->GetFirst();
   while (cluster != nullptr && !cluster->EOS()) {
     ParseCluster(*cluster);
     WalkCues(*segment, GetBlockEntryFromCluster, cluster);

--- a/testing/mkvparser_tests.cc
+++ b/testing/mkvparser_tests.cc
@@ -19,21 +19,21 @@
 #include "mkvparser/mkvreader.h"
 #include "testing/test_util.h"
 
-using mkvparser::AudioTrack;
-using mkvparser::Block;
-using mkvparser::BlockEntry;
-using mkvparser::BlockGroup;
-using mkvparser::Cluster;
-using mkvparser::CuePoint;
-using mkvparser::Cues;
-using mkvparser::MkvReader;
-using mkvparser::Segment;
-using mkvparser::SegmentInfo;
-using mkvparser::Track;
-using mkvparser::Tracks;
-using mkvparser::VideoTrack;
+using adhoc::mkvparser::AudioTrack;
+using adhoc::mkvparser::Block;
+using adhoc::mkvparser::BlockEntry;
+using adhoc::mkvparser::BlockGroup;
+using adhoc::mkvparser::Cluster;
+using adhoc::mkvparser::CuePoint;
+using adhoc::mkvparser::Cues;
+using adhoc::mkvparser::MkvReader;
+using adhoc::mkvparser::Segment;
+using adhoc::mkvparser::SegmentInfo;
+using adhoc::mkvparser::Track;
+using adhoc::mkvparser::Tracks;
+using adhoc::mkvparser::VideoTrack;
 
-namespace test {
+namespace adhoc::test {
 
 // Base class containing boiler plate stuff.
 class ParserTest : public testing::Test {
@@ -66,7 +66,7 @@ class ParserTest : public testing::Test {
     }
     is_reader_open_ = true;
     pos_ = 0;
-    mkvparser::EBMLHeader ebml_header;
+    adhoc::mkvparser::EBMLHeader ebml_header;
     ebml_header.Parse(&reader_, pos_);
     EXPECT_EQ(1, ebml_header.m_version);
     EXPECT_EQ(1, ebml_header.m_readVersion);
@@ -74,7 +74,7 @@ class ParserTest : public testing::Test {
     EXPECT_EQ(expected_doc_type_ver, ebml_header.m_docTypeVersion);
     EXPECT_EQ(2, ebml_header.m_docTypeReadVersion);
 
-    if (mkvparser::Segment::CreateInstance(&reader_, pos_, segment_)) {
+    if (adhoc::mkvparser::Segment::CreateInstance(&reader_, pos_, segment_)) {
       return false;
     }
     return !HasFailure() && segment_->Load() >= 0;
@@ -88,9 +88,9 @@ class ParserTest : public testing::Test {
     filename_ = GetTestFilePath(filename);
     ASSERT_NE(0u, filename_.length());
     ASSERT_EQ(0, reader_.Open(filename_.c_str()));
-    mkvparser::EBMLHeader ebml_header;
+    adhoc::mkvparser::EBMLHeader ebml_header;
     ASSERT_EQ(0, ebml_header.Parse(&reader_, pos_));
-    ASSERT_EQ(0, mkvparser::Segment::CreateInstance(&reader_, pos_, segment_));
+    ASSERT_EQ(0, adhoc::mkvparser::Segment::CreateInstance(&reader_, pos_, segment_));
   }
 
   void CompareBlockContents(const Cluster* const cluster,
@@ -613,7 +613,7 @@ TEST_F(ParserTest, CanParseColour) {
   const VideoTrack* const video_track = dynamic_cast<const VideoTrack*>(
       segment_->GetTracks()->GetTrackByIndex(0));
 
-  const mkvparser::Colour* const colour = video_track->GetColour();
+  const adhoc::mkvparser::Colour* const colour = video_track->GetColour();
   ASSERT_TRUE(colour != nullptr);
   EXPECT_EQ(0u, colour->matrix_coefficients);
   EXPECT_EQ(1u, colour->bits_per_channel);
@@ -629,7 +629,7 @@ TEST_F(ParserTest, CanParseColour) {
   EXPECT_EQ(11u, colour->max_cll);
   EXPECT_EQ(12u, colour->max_fall);
 
-  const mkvparser::MasteringMetadata* const mm =
+  const adhoc::mkvparser::MasteringMetadata* const mm =
       video_track->GetColour()->mastering_metadata;
   ASSERT_TRUE(mm != nullptr);
   ASSERT_TRUE(mm->r != nullptr);
@@ -655,9 +655,9 @@ TEST_F(ParserTest, CanParseProjection) {
   const VideoTrack* const video_track =
       static_cast<const VideoTrack*>(segment_->GetTracks()->GetTrackByIndex(0));
 
-  const mkvparser::Projection* const projection = video_track->GetProjection();
+  const adhoc::mkvparser::Projection* const projection = video_track->GetProjection();
   ASSERT_TRUE(projection != nullptr);
-  EXPECT_EQ(mkvparser::Projection::kRectangular, projection->type);
+  EXPECT_EQ(adhoc::mkvparser::Projection::kRectangular, projection->type);
   EXPECT_FLOAT_EQ(1, projection->pose_yaw);
   EXPECT_FLOAT_EQ(2, projection->pose_pitch);
   EXPECT_FLOAT_EQ(3, projection->pose_roll);
@@ -669,59 +669,59 @@ TEST_F(ParserTest, CanParseProjection) {
 TEST_F(ParserTest, Vp9CodecLevelTest) {
   const int kCodecPrivateLength = 3;
   const uint8_t good_codec_private_level[kCodecPrivateLength] = {2, 1, 11};
-  libwebm::Vp9CodecFeatures features;
-  EXPECT_TRUE(libwebm::ParseVpxCodecPrivate(&good_codec_private_level[0],
+  adhoc::libwebm::Vp9CodecFeatures features;
+  EXPECT_TRUE(adhoc::libwebm::ParseVpxCodecPrivate(&good_codec_private_level[0],
                                             kCodecPrivateLength, &features));
-  EXPECT_EQ(libwebm::Vp9CodecFeatures::kValueNotPresent, features.profile);
+  EXPECT_EQ(adhoc::libwebm::Vp9CodecFeatures::kValueNotPresent, features.profile);
   EXPECT_EQ(11, features.level);
-  EXPECT_EQ(libwebm::Vp9CodecFeatures::kValueNotPresent, features.bit_depth);
-  EXPECT_EQ(libwebm::Vp9CodecFeatures::kValueNotPresent,
+  EXPECT_EQ(adhoc::libwebm::Vp9CodecFeatures::kValueNotPresent, features.bit_depth);
+  EXPECT_EQ(adhoc::libwebm::Vp9CodecFeatures::kValueNotPresent,
             features.chroma_subsampling);
 }
 
 TEST_F(ParserTest, Vp9CodecProfileTest) {
   const int kCodecPrivateLength = 3;
   const uint8_t good_codec_private_profile[kCodecPrivateLength] = {1, 1, 1};
-  libwebm::Vp9CodecFeatures features;
-  EXPECT_TRUE(libwebm::ParseVpxCodecPrivate(&good_codec_private_profile[0],
+  adhoc::libwebm::Vp9CodecFeatures features;
+  EXPECT_TRUE(adhoc::libwebm::ParseVpxCodecPrivate(&good_codec_private_profile[0],
                                             kCodecPrivateLength, &features));
   EXPECT_EQ(1, features.profile);
-  EXPECT_EQ(libwebm::Vp9CodecFeatures::kValueNotPresent, features.level);
-  EXPECT_EQ(libwebm::Vp9CodecFeatures::kValueNotPresent, features.bit_depth);
-  EXPECT_EQ(libwebm::Vp9CodecFeatures::kValueNotPresent,
+  EXPECT_EQ(adhoc::libwebm::Vp9CodecFeatures::kValueNotPresent, features.level);
+  EXPECT_EQ(adhoc::libwebm::Vp9CodecFeatures::kValueNotPresent, features.bit_depth);
+  EXPECT_EQ(adhoc::libwebm::Vp9CodecFeatures::kValueNotPresent,
             features.chroma_subsampling);
 }
 
 TEST_F(ParserTest, Vp9CodecBitDepthTest) {
   const int kCodecPrivateLength = 3;
   const uint8_t good_codec_private_profile[kCodecPrivateLength] = {3, 1, 8};
-  libwebm::Vp9CodecFeatures features;
-  EXPECT_TRUE(libwebm::ParseVpxCodecPrivate(&good_codec_private_profile[0],
+  adhoc::libwebm::Vp9CodecFeatures features;
+  EXPECT_TRUE(adhoc::libwebm::ParseVpxCodecPrivate(&good_codec_private_profile[0],
                                             kCodecPrivateLength, &features));
-  EXPECT_EQ(libwebm::Vp9CodecFeatures::kValueNotPresent, features.profile);
-  EXPECT_EQ(libwebm::Vp9CodecFeatures::kValueNotPresent, features.level);
+  EXPECT_EQ(adhoc::libwebm::Vp9CodecFeatures::kValueNotPresent, features.profile);
+  EXPECT_EQ(adhoc::libwebm::Vp9CodecFeatures::kValueNotPresent, features.level);
   EXPECT_EQ(8, features.bit_depth);
-  EXPECT_EQ(libwebm::Vp9CodecFeatures::kValueNotPresent,
+  EXPECT_EQ(adhoc::libwebm::Vp9CodecFeatures::kValueNotPresent,
             features.chroma_subsampling);
 }
 
 TEST_F(ParserTest, Vp9CodecChromaSubsamplingTest) {
   const int kCodecPrivateLength = 3;
   const uint8_t good_codec_private_profile[kCodecPrivateLength] = {4, 1, 0};
-  libwebm::Vp9CodecFeatures features;
-  EXPECT_TRUE(libwebm::ParseVpxCodecPrivate(&good_codec_private_profile[0],
+  adhoc::libwebm::Vp9CodecFeatures features;
+  EXPECT_TRUE(adhoc::libwebm::ParseVpxCodecPrivate(&good_codec_private_profile[0],
                                             kCodecPrivateLength, &features));
-  EXPECT_EQ(libwebm::Vp9CodecFeatures::kValueNotPresent, features.profile);
-  EXPECT_EQ(libwebm::Vp9CodecFeatures::kValueNotPresent, features.level);
-  EXPECT_EQ(libwebm::Vp9CodecFeatures::kValueNotPresent, features.bit_depth);
+  EXPECT_EQ(adhoc::libwebm::Vp9CodecFeatures::kValueNotPresent, features.profile);
+  EXPECT_EQ(adhoc::libwebm::Vp9CodecFeatures::kValueNotPresent, features.level);
+  EXPECT_EQ(adhoc::libwebm::Vp9CodecFeatures::kValueNotPresent, features.bit_depth);
   EXPECT_EQ(0, features.chroma_subsampling);
 }
 
 TEST_F(ParserTest, Vp9CodecProfileLevelTest) {
   const int kCodecPrivateLength = 6;
   const uint8_t codec_private[kCodecPrivateLength] = {1, 1, 1, 2, 1, 11};
-  libwebm::Vp9CodecFeatures features;
-  EXPECT_TRUE(libwebm::ParseVpxCodecPrivate(&codec_private[0],
+  adhoc::libwebm::Vp9CodecFeatures features;
+  EXPECT_TRUE(adhoc::libwebm::ParseVpxCodecPrivate(&codec_private[0],
                                             kCodecPrivateLength, &features));
   EXPECT_EQ(1, features.profile);
   EXPECT_EQ(11, features.level);
@@ -731,8 +731,8 @@ TEST_F(ParserTest, Vp9CodecAllTest) {
   const int kCodecPrivateLength = 12;
   const uint8_t codec_private[kCodecPrivateLength] = {1, 1, 1, 2, 1, 11,
                                                       3, 1, 8, 4, 1, 0};
-  libwebm::Vp9CodecFeatures features;
-  EXPECT_TRUE(libwebm::ParseVpxCodecPrivate(&codec_private[0],
+  adhoc::libwebm::Vp9CodecFeatures features;
+  EXPECT_TRUE(adhoc::libwebm::ParseVpxCodecPrivate(&codec_private[0],
                                             kCodecPrivateLength, &features));
   EXPECT_EQ(1, features.profile);
   EXPECT_EQ(11, features.level);
@@ -742,44 +742,44 @@ TEST_F(ParserTest, Vp9CodecAllTest) {
 
 TEST_F(ParserTest, Vp9CodecPrivateBadTest) {
   const int kCodecPrivateLength = 3;
-  libwebm::Vp9CodecFeatures features;
+  adhoc::libwebm::Vp9CodecFeatures features;
   // Test invalid codec private data; all of these should return false.
   const uint8_t bad_codec_private[kCodecPrivateLength] = {0, 0, 0};
   EXPECT_FALSE(
-      libwebm::ParseVpxCodecPrivate(NULL, kCodecPrivateLength, &features));
+      adhoc::libwebm::ParseVpxCodecPrivate(NULL, kCodecPrivateLength, &features));
   EXPECT_FALSE(
-      libwebm::ParseVpxCodecPrivate(&bad_codec_private[0], 0, &features));
-  EXPECT_FALSE(libwebm::ParseVpxCodecPrivate(&bad_codec_private[0],
+      adhoc::libwebm::ParseVpxCodecPrivate(&bad_codec_private[0], 0, &features));
+  EXPECT_FALSE(adhoc::libwebm::ParseVpxCodecPrivate(&bad_codec_private[0],
                                              kCodecPrivateLength, &features));
   const uint8_t good_codec_private_level[kCodecPrivateLength] = {2, 1, 11};
 
   // Test parse of codec private chunks, but lie about length.
   EXPECT_FALSE(
-      libwebm::ParseVpxCodecPrivate(&bad_codec_private[0], 0, &features));
-  EXPECT_FALSE(libwebm::ParseVpxCodecPrivate(&good_codec_private_level[0], 0,
+      adhoc::libwebm::ParseVpxCodecPrivate(&bad_codec_private[0], 0, &features));
+  EXPECT_FALSE(adhoc::libwebm::ParseVpxCodecPrivate(&good_codec_private_level[0], 0,
                                              &features));
-  EXPECT_FALSE(libwebm::ParseVpxCodecPrivate(&good_codec_private_level[0],
+  EXPECT_FALSE(adhoc::libwebm::ParseVpxCodecPrivate(&good_codec_private_level[0],
                                              kCodecPrivateLength, NULL));
 }
 
 TEST_F(ParserTest, InvalidTruncatedChapterString) {
   ASSERT_NO_FATAL_FAILURE(CreateSegmentNoHeaderChecks(
       "invalid/chapters_truncated_chapter_string.mkv"));
-  EXPECT_EQ(mkvparser::E_PARSE_FAILED, segment_->Load());
+  EXPECT_EQ(adhoc::mkvparser::E_PARSE_FAILED, segment_->Load());
 }
 
 TEST_F(ParserTest, InvalidTruncatedChapterString2) {
   ASSERT_NO_FATAL_FAILURE(CreateSegmentNoHeaderChecks(
       "invalid/chapters_truncated_chapter_string_2.mkv"));
-  EXPECT_EQ(mkvparser::E_FILE_FORMAT_INVALID, segment_->Load());
+  EXPECT_EQ(adhoc::mkvparser::E_FILE_FORMAT_INVALID, segment_->Load());
 }
 
 TEST_F(ParserTest, InvalidFixedLacingSize) {
   ASSERT_NO_FATAL_FAILURE(
       CreateSegmentNoHeaderChecks("invalid/fixed_lacing_bad_lace_size.mkv"));
   ASSERT_EQ(0, segment_->Load());
-  const mkvparser::BlockEntry* block_entry = NULL;
-  EXPECT_EQ(mkvparser::E_FILE_FORMAT_INVALID,
+  const adhoc::mkvparser::BlockEntry* block_entry = NULL;
+  EXPECT_EQ(adhoc::mkvparser::E_FILE_FORMAT_INVALID,
             segment_->GetFirst()->GetFirst(block_entry));
 }
 
@@ -787,9 +787,9 @@ TEST_F(ParserTest, InvalidBlockEndsBeyondCluster) {
   ASSERT_NO_FATAL_FAILURE(
       CreateSegmentNoHeaderChecks("invalid/block_ends_beyond_cluster.mkv"));
   ASSERT_EQ(0, segment_->Load());
-  const mkvparser::BlockEntry* block_entry = NULL;
+  const adhoc::mkvparser::BlockEntry* block_entry = NULL;
   EXPECT_EQ(0, segment_->GetFirst()->GetFirst(block_entry));
-  EXPECT_EQ(mkvparser::E_FILE_FORMAT_INVALID,
+  EXPECT_EQ(adhoc::mkvparser::E_FILE_FORMAT_INVALID,
             segment_->GetFirst()->GetNext(block_entry, block_entry));
 }
 
@@ -797,26 +797,25 @@ TEST_F(ParserTest, InvalidBlockGroupBlockEndsBlockGroup) {
   ASSERT_NO_FATAL_FAILURE(CreateSegmentNoHeaderChecks(
       "invalid/blockgroup_block_ends_beyond_blockgroup.mkv"));
   ASSERT_EQ(0, segment_->Load());
-  const mkvparser::BlockEntry* block_entry = NULL;
+  const adhoc::mkvparser::BlockEntry* block_entry = NULL;
   EXPECT_EQ(0, segment_->GetFirst()->GetFirst(block_entry));
-  EXPECT_EQ(mkvparser::E_FILE_FORMAT_INVALID,
+  EXPECT_EQ(adhoc::mkvparser::E_FILE_FORMAT_INVALID,
             segment_->GetFirst()->GetNext(block_entry, block_entry));
 }
 
 TEST_F(ParserTest, InvalidProjectionFloatOverflow) {
   ASSERT_NO_FATAL_FAILURE(
       CreateSegmentNoHeaderChecks("invalid/projection_float_overflow.webm"));
-  EXPECT_EQ(mkvparser::E_FILE_FORMAT_INVALID, segment_->Load());
+  EXPECT_EQ(adhoc::mkvparser::E_FILE_FORMAT_INVALID, segment_->Load());
 }
 
 TEST_F(ParserTest, InvalidPrimaryChromaticityParseFail) {
   ASSERT_NO_FATAL_FAILURE(CreateSegmentNoHeaderChecks(
       "invalid/primarychromaticity_fieldtoolarge.webm"));
-  EXPECT_EQ(mkvparser::E_FILE_FORMAT_INVALID, segment_->Load());
+  EXPECT_EQ(adhoc::mkvparser::E_FILE_FORMAT_INVALID, segment_->Load());
 }
 
-}  // namespace test
-
+}  // namespace adhoc::test
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/testing/test_util.cc
+++ b/testing/test_util.cc
@@ -20,7 +20,7 @@
 #include "mkvparser/mkvparser.h"
 #include "mkvparser/mkvreader.h"
 
-namespace test {
+namespace adhoc::test {
 
 std::string GetTestDataDir() {
   const char* test_data_path = std::getenv("LIBWEBM_TEST_DATA_PATH");
@@ -37,10 +37,10 @@ bool CompareFiles(const std::string& file1, const std::string& file2) {
   std::uint8_t buf1[kBlockSize] = {0};
   std::uint8_t buf2[kBlockSize] = {0};
 
-  libwebm::FilePtr f1 =
-      libwebm::FilePtr(std::fopen(file1.c_str(), "rb"), libwebm::FILEDeleter());
-  libwebm::FilePtr f2 =
-      libwebm::FilePtr(std::fopen(file2.c_str(), "rb"), libwebm::FILEDeleter());
+  adhoc::libwebm::FilePtr f1 =
+      adhoc::libwebm::FilePtr(std::fopen(file1.c_str(), "rb"), adhoc::libwebm::FILEDeleter());
+  adhoc::libwebm::FilePtr f2 =
+      adhoc::libwebm::FilePtr(std::fopen(file2.c_str(), "rb"), adhoc::libwebm::FILEDeleter());
 
   if (!f1.get() || !f2.get()) {
     // Files cannot match if one or both couldn't be opened.
@@ -60,12 +60,12 @@ bool CompareFiles(const std::string& file1, const std::string& file2) {
   return std::feof(f1.get()) && std::feof(f2.get());
 }
 
-bool HasCuePoints(const mkvparser::Segment* segment,
+bool HasCuePoints(const adhoc::mkvparser::Segment* segment,
                   std::int64_t* cues_offset) {
   if (!segment || !cues_offset) {
     return false;
   }
-  using mkvparser::SeekHead;
+  using adhoc::mkvparser::SeekHead;
   const SeekHead* const seek_head = segment->GetSeekHead();
   if (!seek_head) {
     return false;
@@ -74,7 +74,7 @@ bool HasCuePoints(const mkvparser::Segment* segment,
   std::int64_t offset = 0;
   for (int i = 0; i < seek_head->GetCount(); ++i) {
     const SeekHead::Entry* const entry = seek_head->GetEntry(i);
-    if (entry->id == libwebm::kMkvCues) {
+    if (entry->id == adhoc::libwebm::kMkvCues) {
       offset = entry->pos;
     }
   }
@@ -88,7 +88,7 @@ bool HasCuePoints(const mkvparser::Segment* segment,
   return true;
 }
 
-bool ValidateCues(mkvparser::Segment* segment, mkvparser::IMkvReader* reader) {
+bool ValidateCues(adhoc::mkvparser::Segment* segment, adhoc::mkvparser::IMkvReader* reader) {
   if (!segment) {
     return false;
   }
@@ -109,11 +109,11 @@ bool ValidateCues(mkvparser::Segment* segment, mkvparser::IMkvReader* reader) {
   // Get a pointer to the video track if it exists. Otherwise, we assume
   // that Cues are based on the first track (which is true for all our test
   // files).
-  const mkvparser::Tracks* const tracks = segment->GetTracks();
-  const mkvparser::Track* cues_track = tracks->GetTrackByIndex(0);
+  const adhoc::mkvparser::Tracks* const tracks = segment->GetTracks();
+  const adhoc::mkvparser::Track* cues_track = tracks->GetTrackByIndex(0);
   for (int i = 1; i < static_cast<int>(tracks->GetTracksCount()); ++i) {
-    const mkvparser::Track* const track = tracks->GetTrackByIndex(i);
-    if (track->GetType() == mkvparser::Track::kVideo) {
+    const adhoc::mkvparser::Track* const track = tracks->GetTrackByIndex(i);
+    if (track->GetType() == adhoc::mkvparser::Track::kVideo) {
       cues_track = track;
       break;
     }
@@ -121,15 +121,15 @@ bool ValidateCues(mkvparser::Segment* segment, mkvparser::IMkvReader* reader) {
 
   // Iterate through Cues and verify if they are pointing to the correct
   // Cluster position.
-  const mkvparser::Cues* const cues = segment->GetCues();
-  const mkvparser::CuePoint* cue_point = NULL;
+  const adhoc::mkvparser::Cues* const cues = segment->GetCues();
+  const adhoc::mkvparser::CuePoint* cue_point = NULL;
   while (cues->LoadCuePoint()) {
     if (!cue_point) {
       cue_point = cues->GetFirst();
     } else {
       cue_point = cues->GetNext(cue_point);
     }
-    const mkvparser::CuePoint::TrackPosition* const track_position =
+    const adhoc::mkvparser::CuePoint::TrackPosition* const track_position =
         cue_point->Find(cues_track);
     const long long cluster_pos = track_position->m_pos +  // NOLINT
                                   segment->m_start;
@@ -137,34 +137,34 @@ bool ValidateCues(mkvparser::Segment* segment, mkvparser::IMkvReader* reader) {
     // If a cluster does not begin at |cluster_pos|, then the file is
     // incorrect.
     long length;  // NOLINT
-    const std::int64_t id = mkvparser::ReadID(reader, cluster_pos, length);
-    if (id != libwebm::kMkvCluster) {
+    const std::int64_t id = adhoc::mkvparser::ReadID(reader, cluster_pos, length);
+    if (id != adhoc::libwebm::kMkvCluster) {
       return false;
     }
   }
   return true;
 }
 
-MkvParser::~MkvParser() {
+adhoc::mkvparser::~MkvParser() {
   delete segment;
   delete reader;
 }
 
 bool ParseMkvFileReleaseParser(const std::string& webm_file,
                                MkvParser* parser_out) {
-  parser_out->reader = new (std::nothrow) mkvparser::MkvReader;
-  mkvparser::MkvReader& reader = *parser_out->reader;
+  parser_out->reader = new (std::nothrow) adhoc::mkvparser::MkvReader;
+  adhoc::mkvparser::MkvReader& reader = *parser_out->reader;
   if (!parser_out->reader || reader.Open(webm_file.c_str()) < 0) {
     return false;
   }
 
   long long pos = 0;  // NOLINT
-  mkvparser::EBMLHeader ebml_header;
+  adhoc::mkvparser::EBMLHeader ebml_header;
   if (ebml_header.Parse(&reader, pos)) {
     return false;
   }
 
-  using mkvparser::Segment;
+  using adhoc::mkvparser::Segment;
   Segment* segment_ptr = nullptr;
   if (Segment::CreateInstance(&reader, pos, segment_ptr)) {
     return false;
@@ -176,7 +176,7 @@ bool ParseMkvFileReleaseParser(const std::string& webm_file,
     return false;
   }
 
-  const mkvparser::Cluster* cluster = segment->GetFirst();
+  const adhoc::mkvparser::Cluster* cluster = segment->GetFirst();
   if (!cluster || cluster->EOS()) {
     return false;
   }
@@ -186,7 +186,7 @@ bool ParseMkvFileReleaseParser(const std::string& webm_file,
       return false;
     }
 
-    const mkvparser::BlockEntry* block = nullptr;
+    const adhoc::mkvparser::BlockEntry* block = nullptr;
     if (cluster->GetFirst(block) < 0) {
       return false;
     }
@@ -212,4 +212,4 @@ bool ParseMkvFile(const std::string& webm_file) {
   return result;
 }
 
-}  // namespace test
+}  // namespace adhoc::test

--- a/testing/test_util.h
+++ b/testing/test_util.h
@@ -13,13 +13,12 @@
 #include <cstddef>
 #include <string>
 
-namespace mkvparser {
+namespace adhoc::mkvparser {
 class IMkvReader;
 class MkvReader;
 class Segment;
-}  // namespace mkvparser
-
-namespace test {
+}  // namespace adhoc::mkvparser
+namespace adhoc::test {
 
 // constants for muxer and parser tests
 const char kAppString[] = "mkvmuxer_unit_tests";
@@ -60,13 +59,13 @@ bool CompareFiles(const std::string& file1, const std::string& file2);
 
 // Returns true and sets |cues_offset| to the cues location within the MKV file
 // parsed by |segment| when the MKV file has cue points.
-bool HasCuePoints(const mkvparser::Segment* segment, std::int64_t* cues_offset);
+bool HasCuePoints(const adhoc::mkvparser::Segment* segment, std::int64_t* cues_offset);
 
 // Validates cue points. Assumes caller has already called Load() on |segment|.
 // Returns true when:
 //  All cue points point at clusters, OR
 //  Data parsed by |segment| has no cue points.
-bool ValidateCues(mkvparser::Segment* segment, mkvparser::IMkvReader* reader);
+bool ValidateCues(adhoc::mkvparser::Segment* segment, adhoc::mkvparser::IMkvReader* reader);
 
 // Parses |webm_file| using mkvparser and returns true when file parses
 // successfully (all clusters and blocks can be successfully walked). Second
@@ -76,13 +75,12 @@ bool ValidateCues(mkvparser::Segment* segment, mkvparser::IMkvReader* reader);
 struct MkvParser {
   MkvParser() = default;
   ~MkvParser();
-  mkvparser::Segment* segment = nullptr;
-  mkvparser::MkvReader* reader = nullptr;
+  adhoc::mkvparser::Segment* segment = nullptr;
+  adhoc::mkvparser::MkvReader* reader = nullptr;
 };
 bool ParseMkvFile(const std::string& webm_file);
 bool ParseMkvFileReleaseParser(const std::string& webm_file,
                                MkvParser* parser_out);
 
-}  // namespace test
-
+}  // namespace adhoc::test
 #endif  // LIBWEBM_TESTING_TEST_UTIL_H_

--- a/testing/video_frame_tests.cc
+++ b/testing/video_frame_tests.cc
@@ -10,23 +10,23 @@
 #include "gtest/gtest.h"
 
 namespace {
-const libwebm::VideoFrame::Codec kCodec = libwebm::VideoFrame::kVP8;
+const adhoc::libwebm::VideoFrame::Codec kCodec = adhoc::libwebm::VideoFrame::kVP8;
 const std::int64_t kPts = 12345;
 const std::size_t kSize = 1;
 const std::size_t kEmptySize = 0;
 
 TEST(VideoFrameTests, DefaultsTest) {
-  libwebm::VideoFrame frame;
+  adhoc::libwebm::VideoFrame frame;
   EXPECT_EQ(kEmptySize, frame.buffer().capacity);
   EXPECT_EQ(kEmptySize, frame.buffer().length);
   EXPECT_EQ(nullptr, frame.buffer().data.get());
   EXPECT_FALSE(frame.keyframe());
   EXPECT_EQ(0, frame.nanosecond_pts());
-  EXPECT_EQ(libwebm::VideoFrame::kVP9, frame.codec());
+  EXPECT_EQ(adhoc::libwebm::VideoFrame::kVP9, frame.codec());
 }
 
 TEST(VideoFrameTests, SizeTest) {
-  libwebm::VideoFrame frame;
+  adhoc::libwebm::VideoFrame frame;
   EXPECT_TRUE(frame.Init(kSize));
 
   // Buffer inits empty, length should be 0, aka |kEmpty|.
@@ -49,7 +49,7 @@ TEST(VideoFrameTests, OverloadsTest) {
   const bool kKeyframe = true;
 
   // Test VideoFrame::VideoFrame(bool keyframe, int64_t nano_pts, Codec c).
-  libwebm::VideoFrame keyframe(kKeyframe, kPts, kCodec);
+  adhoc::libwebm::VideoFrame keyframe(kKeyframe, kPts, kCodec);
   EXPECT_EQ(kKeyframe, keyframe.keyframe());
   EXPECT_EQ(kPts, keyframe.nanosecond_pts());
   EXPECT_EQ(kCodec, keyframe.codec());
@@ -65,7 +65,7 @@ TEST(VideoFrameTests, OverloadsTest) {
   EXPECT_NE(nullptr, keyframe.buffer().data.get());
 
   // Test VideoFrame::Init(size_t length, int64_t nano_pts, Codec c).
-  EXPECT_TRUE(keyframe.Init(kSize, kPts + 1, libwebm::VideoFrame::kVP9));
+  EXPECT_TRUE(keyframe.Init(kSize, kPts + 1, adhoc::libwebm::VideoFrame::kVP9));
   EXPECT_EQ(kSize, keyframe.buffer().capacity);
   EXPECT_GT(kSize, keyframe.buffer().length);
   EXPECT_NE(kPts, keyframe.nanosecond_pts());

--- a/vttdemux.cc
+++ b/vttdemux.cc
@@ -20,12 +20,12 @@
 
 using std::string;
 
-namespace libwebm {
+namespace adhoc::libwebm {
 namespace vttdemux {
 
 typedef long long mkvtime_t;  // NOLINT
 typedef long long mkvpos_t;  // NOLINT
-typedef std::unique_ptr<mkvparser::Segment> segment_ptr_t;
+typedef std::unique_ptr<adhoc::mkvparser::Segment> segment_ptr_t;
 
 // WebVTT metadata tracks have a type (encoded in the CodecID for the track).
 // We use |type| to synthesize a filename for the out-of-band WebVTT |file|.
@@ -45,15 +45,15 @@ enum { kChaptersKey = 0 };
 // The data from the original WebVTT Cue is stored as a WebM block.
 // The FrameParser is used to parse the lines of text out from the
 // block, in order to reconstruct the original WebVTT Cue.
-class FrameParser : public libwebvtt::LineReader {
+class FrameParser : public adhoc::libwebvtt::LineReader {
  public:
   //  Bind the FrameParser instance to a WebM block.
-  explicit FrameParser(const mkvparser::BlockGroup* block_group);
+  explicit FrameParser(const adhoc::mkvparser::BlockGroup* block_group);
   virtual ~FrameParser();
 
   // The Webm block (group) to which this instance is bound.  We
   // treat the payload of the block as a stream of characters.
-  const mkvparser::BlockGroup* const block_group_;
+  const adhoc::mkvparser::BlockGroup* const block_group_;
 
  protected:
   // Read the next character from the character stream (the payload
@@ -85,12 +85,12 @@ class FrameParser : public libwebvtt::LineReader {
 // The ChapterAtomParser is used to parse the lines of text out from
 // the String sub-element of the Display element (though it would be
 // admittedly odd if there were more than one line).
-class ChapterAtomParser : public libwebvtt::LineReader {
+class ChapterAtomParser : public adhoc::libwebvtt::LineReader {
  public:
-  explicit ChapterAtomParser(const mkvparser::Chapters::Display* display);
+  explicit ChapterAtomParser(const adhoc::mkvparser::Chapters::Display* display);
   virtual ~ChapterAtomParser();
 
-  const mkvparser::Chapters::Display* const display_;
+  const adhoc::mkvparser::Chapters::Display* const display_;
 
  protected:
   // Read the next character from the character stream (the title
@@ -120,11 +120,11 @@ class ChapterAtomParser : public libwebvtt::LineReader {
 
 // Parse the EBML header of the WebM input file, to determine whether we
 // actually have a WebM file.  Returns false if this is not a WebM file.
-bool ParseHeader(mkvparser::IMkvReader* reader, mkvpos_t* pos);
+bool ParseHeader(adhoc::mkvparser::IMkvReader* reader, mkvpos_t* pos);
 
 // Parse the Segment of the input file and load all of its clusters.
 // Returns false if there was an error parsing the file.
-bool ParseSegment(mkvparser::IMkvReader* reader, mkvpos_t pos,
+bool ParseSegment(adhoc::mkvparser::IMkvReader* reader, mkvpos_t pos,
                   segment_ptr_t* segment);
 
 // If |segment| has a Chapters element (in which case, there will be a
@@ -132,32 +132,32 @@ bool ParseSegment(mkvparser::IMkvReader* reader, mkvpos_t pos,
 // WebVTT chapter cues and write them to the output file.  Returns
 // false on error.
 bool WriteChaptersFile(const metadata_map_t& metadata_map,
-                       const mkvparser::Segment* segment);
+                       const adhoc::mkvparser::Segment* segment);
 
 // Convert an MKV Chapters Atom to a WebVTT cue and write it to the
 // output |file|.  Returns false on error.
-bool WriteChaptersCue(FILE* file, const mkvparser::Chapters* chapters,
-                      const mkvparser::Chapters::Atom* atom,
-                      const mkvparser::Chapters::Display* display);
+bool WriteChaptersCue(FILE* file, const adhoc::mkvparser::Chapters* chapters,
+                      const adhoc::mkvparser::Chapters::Atom* atom,
+                      const adhoc::mkvparser::Chapters::Display* display);
 
 // Write the Cue Identifier line of the WebVTT cue, if it's present.
 // Returns false on error.
 bool WriteChaptersCueIdentifier(FILE* file,
-                                const mkvparser::Chapters::Atom* atom);
+                                const adhoc::mkvparser::Chapters::Atom* atom);
 
 // Use the timecodes from the chapters |atom| to write just the
 // timings line of the WebVTT cue.  Returns false on error.
-bool WriteChaptersCueTimings(FILE* file, const mkvparser::Chapters* chapters,
-                             const mkvparser::Chapters::Atom* atom);
+bool WriteChaptersCueTimings(FILE* file, const adhoc::mkvparser::Chapters* chapters,
+                             const adhoc::mkvparser::Chapters::Atom* atom);
 
 // Parse the String sub-element of the |display| and write the payload
 // of the WebVTT cue.  Returns false on error.
 bool WriteChaptersCuePayload(FILE* file,
-                             const mkvparser::Chapters::Display* display);
+                             const adhoc::mkvparser::Chapters::Display* display);
 
 // Iterate over the tracks of the input file (and any chapters
 // element) and cache information about each metadata track.
-void BuildMap(const mkvparser::Segment* segment, metadata_map_t* metadata_map);
+void BuildMap(const adhoc::mkvparser::Segment* segment, metadata_map_t* metadata_map);
 
 // For each track listed in the cache, synthesize its output filename
 // and open a file handle that designates the out-of-band file.
@@ -170,7 +170,7 @@ void CloseFiles(metadata_map_t* metadata_map);
 // Iterate over the clusters of the input file, and write a WebVTT cue
 // for each metadata block.  Returns false if processing of a cluster
 // failed.
-bool WriteFiles(const metadata_map_t& m, mkvparser::Segment* s);
+bool WriteFiles(const metadata_map_t& m, adhoc::mkvparser::Segment* s);
 
 // Write the WebVTT header for each track in the cache.  We do this
 // immediately before writing the actual WebVTT cues.  Returns false
@@ -181,18 +181,18 @@ bool InitializeFiles(const metadata_map_t& metadata_map);
 // its associated output file for each block of metadata.  Returns
 // false if processing a block failed, or there was a parse error.
 bool ProcessCluster(const metadata_map_t& metadata_map,
-                    const mkvparser::Cluster* cluster);
+                    const adhoc::mkvparser::Cluster* cluster);
 
 // Look up this track number in the cache, and if found (meaning this
 // is a metadata track), write a WebVTT cue to the associated output
 // file.  Returns false if writing the WebVTT cue failed.
 bool ProcessBlockEntry(const metadata_map_t& metadata_map,
-                       const mkvparser::BlockEntry* block_entry);
+                       const adhoc::mkvparser::BlockEntry* block_entry);
 
 // Parse the lines of text from the |block_group| to reconstruct the
 // original WebVTT cue, and write it to the associated output |file|.
 // Returns false if there was an error writing to the output file.
-bool WriteCue(FILE* file, const mkvparser::BlockGroup* block_group);
+bool WriteCue(FILE* file, const adhoc::mkvparser::BlockGroup* block_group);
 
 // Consume a line of text from the character stream, and if the line
 // is not empty write the cue identifier to the associated output
@@ -219,10 +219,10 @@ bool WriteCuePayload(FILE* f, FrameParser* parser);
 
 namespace vttdemux {
 
-FrameParser::FrameParser(const mkvparser::BlockGroup* block_group)
+FrameParser::FrameParser(const adhoc::mkvparser::BlockGroup* block_group)
     : block_group_(block_group) {
-  const mkvparser::Block* const block = block_group->GetBlock();
-  const mkvparser::Block::Frame& f = block->GetFrame(0);
+  const adhoc::mkvparser::Block* const block = block_group->GetBlock();
+  const adhoc::mkvparser::Block::Frame& f = block->GetFrame(0);
 
   // The beginning and end of the character stream corresponds to the
   // position of this block's frame within the WebM input file.
@@ -235,11 +235,11 @@ FrameParser::~FrameParser() {}
 
 int FrameParser::GetChar(char* c) {
   if (pos_ >= pos_end_)  // end-of-stream
-    return 1;  // per the semantics of libwebvtt::Reader::GetChar
+    return 1;  // per the semantics of adhoc::libwebvtt::Reader::GetChar
 
-  const mkvparser::Cluster* const cluster = block_group_->GetCluster();
-  const mkvparser::Segment* const segment = cluster->m_pSegment;
-  mkvparser::IMkvReader* const reader = segment->m_pReader;
+  const adhoc::mkvparser::Cluster* const cluster = block_group_->GetCluster();
+  const adhoc::mkvparser::Segment* const segment = cluster->m_pSegment;
+  adhoc::mkvparser::IMkvReader* const reader = segment->m_pReader;
 
   unsigned char* const buf = reinterpret_cast<unsigned char*>(c);
   const int result = reader->Read(pos_, 1, buf);
@@ -259,7 +259,7 @@ void FrameParser::UngetChar(char /* c */) {
 }
 
 ChapterAtomParser::ChapterAtomParser(
-    const mkvparser::Chapters::Display* display)
+    const adhoc::mkvparser::Chapters::Display* display)
     : display_(display) {
   str_ = display->GetString();
   if (str_ == NULL)
@@ -272,7 +272,7 @@ ChapterAtomParser::~ChapterAtomParser() {}
 
 int ChapterAtomParser::GetChar(char* c) {
   if (str_ == NULL || str_ >= str_end_)  // end-of-stream
-    return 1;  // per the semantics of libwebvtt::Reader::GetChar
+    return 1;  // per the semantics of adhoc::libwebvtt::Reader::GetChar
 
   *c = *str_++;  // consume this character in the stream
   return 0;
@@ -287,8 +287,8 @@ void ChapterAtomParser::UngetChar(char /* c */) {
 
 }  // namespace vttdemux
 
-bool vttdemux::ParseHeader(mkvparser::IMkvReader* reader, mkvpos_t* pos) {
-  mkvparser::EBMLHeader h;
+bool vttdemux::ParseHeader(adhoc::mkvparser::IMkvReader* reader, mkvpos_t* pos) {
+  adhoc::mkvparser::EBMLHeader h;
   const mkvpos_t status = h.Parse(reader, *pos);
 
   if (status) {
@@ -304,12 +304,12 @@ bool vttdemux::ParseHeader(mkvparser::IMkvReader* reader, mkvpos_t* pos) {
   return true;  // success
 }
 
-bool vttdemux::ParseSegment(mkvparser::IMkvReader* reader, mkvpos_t pos,
+bool vttdemux::ParseSegment(adhoc::mkvparser::IMkvReader* reader, mkvpos_t pos,
                             segment_ptr_t* segment_ptr) {
   // We first create the segment object.
 
-  mkvparser::Segment* p;
-  const mkvpos_t create = mkvparser::Segment::CreateInstance(reader, pos, p);
+  adhoc::mkvparser::Segment* p;
+  const mkvpos_t create = adhoc::mkvparser::Segment::CreateInstance(reader, pos, p);
 
   if (create) {
     printf("error parsing segment element\n");
@@ -330,7 +330,7 @@ bool vttdemux::ParseSegment(mkvparser::IMkvReader* reader, mkvpos_t pos,
   return true;
 }
 
-void vttdemux::BuildMap(const mkvparser::Segment* segment,
+void vttdemux::BuildMap(const adhoc::mkvparser::Segment* segment,
                         metadata_map_t* map_ptr) {
   metadata_map_t& m = *map_ptr;
   m.clear();
@@ -343,7 +343,7 @@ void vttdemux::BuildMap(const mkvparser::Segment* segment,
     m[kChaptersKey] = info;
   }
 
-  const mkvparser::Tracks* const tt = segment->GetTracks();
+  const adhoc::mkvparser::Tracks* const tt = segment->GetTracks();
   if (tt == NULL)
     return;
 
@@ -355,7 +355,7 @@ void vttdemux::BuildMap(const mkvparser::Segment* segment,
   // a track holds metadata by inspecting its CodecID.
 
   for (long idx = 0; idx < tc; ++idx) {  // NOLINT
-    const mkvparser::Track* const t = tt->GetTrackByIndex(idx);
+    const adhoc::mkvparser::Track* const t = tt->GetTrackByIndex(idx);
 
     if (t == NULL)  // weird
       continue;
@@ -530,7 +530,7 @@ void vttdemux::CloseFiles(metadata_map_t* metadata_map) {
   }
 }
 
-bool vttdemux::WriteFiles(const metadata_map_t& m, mkvparser::Segment* s) {
+bool vttdemux::WriteFiles(const metadata_map_t& m, adhoc::mkvparser::Segment* s) {
   // First write the WebVTT header.
 
   InitializeFiles(m);
@@ -541,7 +541,7 @@ bool vttdemux::WriteFiles(const metadata_map_t& m, mkvparser::Segment* s) {
   // Now iterate over the clusters, writing the WebVTT cue as we parse
   // each metadata block.
 
-  const mkvparser::Cluster* cluster = s->GetFirst();
+  const adhoc::mkvparser::Cluster* cluster = s->GetFirst();
 
   while (cluster != NULL && !cluster->EOS()) {
     if (!ProcessCluster(m, cluster))
@@ -575,12 +575,12 @@ bool vttdemux::InitializeFiles(const metadata_map_t& m) {
 }
 
 bool vttdemux::WriteChaptersFile(const metadata_map_t& m,
-                                 const mkvparser::Segment* s) {
+                                 const adhoc::mkvparser::Segment* s) {
   const metadata_map_t::const_iterator info_iter = m.find(kChaptersKey);
   if (info_iter == m.end())  // no chapters, so nothing to do
     return true;
 
-  const mkvparser::Chapters* const chapters = s->GetChapters();
+  const adhoc::mkvparser::Chapters* const chapters = s->GetChapters();
   if (chapters == NULL)  // weird
     return true;
 
@@ -598,12 +598,12 @@ bool vttdemux::WriteChaptersFile(const metadata_map_t& m,
     return false;
   }
 
-  const mkvparser::Chapters::Edition* const edition = chapters->GetEdition(0);
+  const adhoc::mkvparser::Chapters::Edition* const edition = chapters->GetEdition(0);
 
   const int atom_count = edition->GetAtomCount();
 
   for (int idx = 0; idx < atom_count; ++idx) {
-    const mkvparser::Chapters::Atom* const atom = edition->GetAtom(idx);
+    const adhoc::mkvparser::Chapters::Atom* const atom = edition->GetAtom(idx);
     const int display_count = atom->GetDisplayCount();
 
     if (display_count <= 0)
@@ -615,7 +615,7 @@ bool vttdemux::WriteChaptersFile(const metadata_map_t& m,
       return false;
     }
 
-    const mkvparser::Chapters::Display* const display = atom->GetDisplay(0);
+    const adhoc::mkvparser::Chapters::Display* const display = atom->GetDisplay(0);
 
     if (const char* language = display->GetLanguage()) {
       if (strcmp(language, "eng") != 0) {
@@ -646,9 +646,9 @@ bool vttdemux::WriteChaptersFile(const metadata_map_t& m,
   return true;
 }
 
-bool vttdemux::WriteChaptersCue(FILE* f, const mkvparser::Chapters* chapters,
-                                const mkvparser::Chapters::Atom* atom,
-                                const mkvparser::Chapters::Display* display) {
+bool vttdemux::WriteChaptersCue(FILE* f, const adhoc::mkvparser::Chapters* chapters,
+                                const adhoc::mkvparser::Chapters::Atom* atom,
+                                const adhoc::mkvparser::Chapters::Display* display) {
   // We start a new cue by writing a cue separator (an empty line)
   // into the stream.
 
@@ -672,7 +672,7 @@ bool vttdemux::WriteChaptersCue(FILE* f, const mkvparser::Chapters* chapters,
 }
 
 bool vttdemux::WriteChaptersCueIdentifier(
-    FILE* f, const mkvparser::Chapters::Atom* atom) {
+    FILE* f, const adhoc::mkvparser::Chapters::Atom* atom) {
   const char* const identifier = atom->GetStringUID();
 
   if (identifier == NULL)
@@ -685,8 +685,8 @@ bool vttdemux::WriteChaptersCueIdentifier(
 }
 
 bool vttdemux::WriteChaptersCueTimings(FILE* f,
-                                       const mkvparser::Chapters* chapters,
-                                       const mkvparser::Chapters::Atom* atom) {
+                                       const adhoc::mkvparser::Chapters* chapters,
+                                       const adhoc::mkvparser::Chapters::Atom* atom) {
   const mkvtime_t start_ns = atom->GetStartTime(chapters);
 
   if (start_ns < 0)
@@ -713,7 +713,7 @@ bool vttdemux::WriteChaptersCueTimings(FILE* f,
 }
 
 bool vttdemux::WriteChaptersCuePayload(
-    FILE* f, const mkvparser::Chapters::Display* display) {
+    FILE* f, const adhoc::mkvparser::Chapters::Display* display) {
   // Bind a Chapter parser object to the display, which allows us to
   // extract each line of text from the title-part of the display.
   ChapterAtomParser parser(display);
@@ -741,11 +741,11 @@ bool vttdemux::WriteChaptersCuePayload(
 }
 
 bool vttdemux::ProcessCluster(const metadata_map_t& m,
-                              const mkvparser::Cluster* c) {
+                              const adhoc::mkvparser::Cluster* c) {
   // Visit the blocks in this cluster, writing a WebVTT cue for each
   // metadata block.
 
-  const mkvparser::BlockEntry* block_entry;
+  const adhoc::mkvparser::BlockEntry* block_entry;
 
   long result = c->GetFirst(block_entry);  // NOLINT
   if (result < 0) {
@@ -768,11 +768,11 @@ bool vttdemux::ProcessCluster(const metadata_map_t& m,
 }
 
 bool vttdemux::ProcessBlockEntry(const metadata_map_t& m,
-                                 const mkvparser::BlockEntry* block_entry) {
+                                 const adhoc::mkvparser::BlockEntry* block_entry) {
   // If the track number for this block is in the cache, then we have
   // a metadata block, so write the WebVTT cue to the output file.
 
-  const mkvparser::Block* const block = block_entry->GetBlock();
+  const adhoc::mkvparser::Block* const block = block_entry->GetBlock();
   const long long tn = block->GetTrackNumber();  // NOLINT
 
   typedef metadata_map_t::const_iterator iter_t;
@@ -781,10 +781,10 @@ bool vttdemux::ProcessBlockEntry(const metadata_map_t& m,
   if (i == m.end())  // not a metadata track
     return true;  // nothing else to do
 
-  if (block_entry->GetKind() != mkvparser::BlockEntry::kBlockGroup)
+  if (block_entry->GetKind() != adhoc::mkvparser::BlockEntry::kBlockGroup)
     return false;  // weird
 
-  typedef mkvparser::BlockGroup BG;
+  typedef adhoc::mkvparser::BlockGroup BG;
   const BG* const block_group = static_cast<const BG*>(block_entry);
 
   const MetadataInfo& info = i->second;
@@ -793,7 +793,7 @@ bool vttdemux::ProcessBlockEntry(const metadata_map_t& m,
   return WriteCue(f, block_group);
 }
 
-bool vttdemux::WriteCue(FILE* f, const mkvparser::BlockGroup* block_group) {
+bool vttdemux::WriteCue(FILE* f, const adhoc::mkvparser::BlockGroup* block_group) {
   // Bind a FrameParser object to the block, which allows us to
   // extract each line of text from the payload of the block.
   FrameParser parser(block_group);
@@ -844,9 +844,9 @@ bool vttdemux::WriteCueIdentifier(FILE* f, FrameParser* parser) {
 }
 
 bool vttdemux::WriteCueTimings(FILE* f, FrameParser* parser) {
-  const mkvparser::BlockGroup* const block_group = parser->block_group_;
-  const mkvparser::Cluster* const cluster = block_group->GetCluster();
-  const mkvparser::Block* const block = block_group->GetBlock();
+  const adhoc::mkvparser::BlockGroup* const block_group = parser->block_group_;
+  const adhoc::mkvparser::Cluster* const cluster = block_group->GetCluster();
+  const adhoc::mkvparser::Block* const block = block_group->GetBlock();
 
   // A WebVTT Cue "timings" line comprises two parts: the start and
   // stop time for this cue, followed by the (optional) cue settings,
@@ -868,8 +868,8 @@ bool vttdemux::WriteCueTimings(FILE* f, FrameParser* parser) {
   if (duration_timecode < 0)
     return false;
 
-  const mkvparser::Segment* const segment = cluster->m_pSegment;
-  const mkvparser::SegmentInfo* const info = segment->GetInfo();
+  const adhoc::mkvparser::Segment* const segment = cluster->m_pSegment;
+  const adhoc::mkvparser::SegmentInfo* const info = segment->GetInfo();
 
   if (info == NULL)
     return false;
@@ -951,7 +951,7 @@ bool vttdemux::WriteCuePayload(FILE* f, FrameParser* parser) {
   return true;
 }
 
-}  // namespace libwebm
+}  // namespace adhoc::libwebm
 
 int main(int argc, const char* argv[]) {
   if (argc != 2) {
@@ -960,7 +960,7 @@ int main(int argc, const char* argv[]) {
   }
 
   const char* const filename = argv[1];
-  mkvparser::MkvReader reader;
+  adhoc::mkvparser::MkvReader reader;
 
   int e = reader.Open(filename);
 
@@ -969,17 +969,17 @@ int main(int argc, const char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  libwebm::vttdemux::mkvpos_t pos;
+  adhoc::libwebm::vttdemux::mkvpos_t pos;
 
-  if (!libwebm::vttdemux::ParseHeader(&reader, &pos))
+  if (!adhoc::libwebm::vttdemux::ParseHeader(&reader, &pos))
     return EXIT_FAILURE;
 
-  libwebm::vttdemux::segment_ptr_t segment_ptr;
+  adhoc::libwebm::vttdemux::segment_ptr_t segment_ptr;
 
-  if (!libwebm::vttdemux::ParseSegment(&reader, pos, &segment_ptr))
+  if (!adhoc::libwebm::vttdemux::ParseSegment(&reader, pos, &segment_ptr))
     return EXIT_FAILURE;
 
-  libwebm::vttdemux::metadata_map_t metadata_map;
+  adhoc::libwebm::vttdemux::metadata_map_t metadata_map;
 
   BuildMap(segment_ptr.get(), &metadata_map);
 

--- a/webm_info.cc
+++ b/webm_info.cc
@@ -28,10 +28,10 @@
 
 namespace {
 
-using libwebm::Indent;
-using libwebm::kNanosecondsPerSecond;
-using libwebm::kNanosecondsPerSecondi;
-using mkvparser::ContentEncoding;
+using adhoc::libwebm::Indent;
+using adhoc::libwebm::kNanosecondsPerSecond;
+using adhoc::libwebm::kNanosecondsPerSecondi;
+using adhoc::mkvparser::ContentEncoding;
 using std::string;
 using std::wstring;
 
@@ -179,10 +179,10 @@ wstring UTF8ToWideString(const char* str) {
 
 string ToString(const char* str) { return string((str == NULL) ? "" : str); }
 
-void OutputEBMLHeader(const mkvparser::EBMLHeader& ebml, FILE* o,
+void OutputEBMLHeader(const adhoc::mkvparser::EBMLHeader& ebml, FILE* o,
                       Indent* indent) {
   fprintf(o, "EBML Header:\n");
-  indent->Adjust(libwebm::kIncreaseIndent);
+  indent->Adjust(adhoc::libwebm::kIncreaseIndent);
   fprintf(o, "%sEBMLVersion       : %lld\n", indent->indent_str().c_str(),
           ebml.m_version);
   fprintf(o, "%sEBMLReadVersion   : %lld\n", indent->indent_str().c_str(),
@@ -197,10 +197,10 @@ void OutputEBMLHeader(const mkvparser::EBMLHeader& ebml, FILE* o,
           ebml.m_docTypeVersion);
   fprintf(o, "%sDocTypeReadVersion: %lld\n", indent->indent_str().c_str(),
           ebml.m_docTypeReadVersion);
-  indent->Adjust(libwebm::kDecreaseIndent);
+  indent->Adjust(adhoc::libwebm::kDecreaseIndent);
 }
 
-void OutputSegment(const mkvparser::Segment& segment, const Options& options,
+void OutputSegment(const adhoc::mkvparser::Segment& segment, const Options& options,
                    FILE* o) {
   fprintf(o, "Segment:");
   if (options.output_offset)
@@ -211,9 +211,9 @@ void OutputSegment(const mkvparser::Segment& segment, const Options& options,
   fprintf(o, "\n");
 }
 
-bool OutputSeekHead(const mkvparser::Segment& segment, const Options& options,
+bool OutputSeekHead(const adhoc::mkvparser::Segment& segment, const Options& options,
                     FILE* o, Indent* indent) {
-  const mkvparser::SeekHead* const seekhead = segment.GetSeekHead();
+  const adhoc::mkvparser::SeekHead* const seekhead = segment.GetSeekHead();
   if (!seekhead) {
     // SeekHeads are optional.
     return true;
@@ -226,10 +226,10 @@ bool OutputSeekHead(const mkvparser::Segment& segment, const Options& options,
     fprintf(o, "  size: %lld", seekhead->m_element_size);
   fprintf(o, "\n");
 
-  indent->Adjust(libwebm::kIncreaseIndent);
+  indent->Adjust(adhoc::libwebm::kIncreaseIndent);
 
   for (int i = 0; i < seekhead->GetCount(); ++i) {
-    const mkvparser::SeekHead::Entry* const entry = seekhead->GetEntry(i);
+    const adhoc::mkvparser::SeekHead::Entry* const entry = seekhead->GetEntry(i);
     if (!entry) {
       fprintf(stderr, "Error retrieving SeekHead entry #%d\n", i);
       return false;
@@ -242,17 +242,17 @@ bool OutputSeekHead(const mkvparser::Segment& segment, const Options& options,
       fprintf(o, "  size: %lld", entry->element_size);
     fprintf(o, "\n");
 
-    indent->Adjust(libwebm::kIncreaseIndent);
+    indent->Adjust(adhoc::libwebm::kIncreaseIndent);
     std::string entry_indent = indent->indent_str();
     // TODO(jzern): 1) known ids could be stringified. 2) ids could be
     // reencoded to EBML for ease of lookup.
     fprintf(o, "%sSeek ID       : %llx\n", entry_indent.c_str(), entry->id);
     fprintf(o, "%sSeek position : %lld\n", entry_indent.c_str(), entry->pos);
-    indent->Adjust(libwebm::kDecreaseIndent);
+    indent->Adjust(adhoc::libwebm::kDecreaseIndent);
   }
 
   for (int i = 0; i < seekhead->GetVoidElementCount(); ++i) {
-    const mkvparser::SeekHead::VoidElement* const entry =
+    const adhoc::mkvparser::SeekHead::VoidElement* const entry =
         seekhead->GetVoidElement(i);
     if (!entry) {
       fprintf(stderr, "Error retrieving SeekHead void element #%d\n", i);
@@ -267,13 +267,13 @@ bool OutputSeekHead(const mkvparser::Segment& segment, const Options& options,
     fprintf(o, "\n");
   }
 
-  indent->Adjust(libwebm::kDecreaseIndent);
+  indent->Adjust(adhoc::libwebm::kDecreaseIndent);
   return true;
 }
 
-bool OutputSegmentInfo(const mkvparser::Segment& segment,
+bool OutputSegmentInfo(const adhoc::mkvparser::Segment& segment,
                        const Options& options, FILE* o, Indent* indent) {
-  const mkvparser::SegmentInfo* const segment_info = segment.GetInfo();
+  const adhoc::mkvparser::SegmentInfo* const segment_info = segment.GetInfo();
   if (!segment_info) {
     fprintf(stderr, "SegmentInfo was NULL.\n");
     return false;
@@ -294,7 +294,7 @@ bool OutputSegmentInfo(const mkvparser::Segment& segment,
     fprintf(o, "  size: %lld", segment_info->m_element_size);
   fprintf(o, "\n");
 
-  indent->Adjust(libwebm::kIncreaseIndent);
+  indent->Adjust(adhoc::libwebm::kIncreaseIndent);
   fprintf(o, "%sTimecodeScale : %" PRId64 " \n", indent->indent_str().c_str(),
           timecode_scale);
   if (options.output_seconds)
@@ -313,13 +313,13 @@ bool OutputSegmentInfo(const mkvparser::Segment& segment,
   if (!writing_app.empty())
     fprintf(o, "%sWritingApp    : %ls\n", indent->indent_str().c_str(),
             writing_app.c_str());
-  indent->Adjust(libwebm::kDecreaseIndent);
+  indent->Adjust(adhoc::libwebm::kDecreaseIndent);
   return true;
 }
 
-bool OutputTracks(const mkvparser::Segment& segment, const Options& options,
+bool OutputTracks(const adhoc::mkvparser::Segment& segment, const Options& options,
                   FILE* o, Indent* indent) {
-  const mkvparser::Tracks* const tracks = segment.GetTracks();
+  const adhoc::mkvparser::Tracks* const tracks = segment.GetTracks();
   if (!tracks) {
     fprintf(stderr, "Tracks was NULL.\n");
     return false;
@@ -335,11 +335,11 @@ bool OutputTracks(const mkvparser::Segment& segment, const Options& options,
   unsigned int i = 0;
   const unsigned long j = tracks->GetTracksCount();
   while (i != j) {
-    const mkvparser::Track* const track = tracks->GetTrackByIndex(i++);
+    const adhoc::mkvparser::Track* const track = tracks->GetTrackByIndex(i++);
     if (track == NULL)
       continue;
 
-    indent->Adjust(libwebm::kIncreaseIndent);
+    indent->Adjust(adhoc::libwebm::kIncreaseIndent);
     fprintf(o, "%sTrack:", indent->indent_str().c_str());
     if (options.output_offset)
       fprintf(o, "  @: %lld", track->m_element_start);
@@ -351,7 +351,7 @@ bool OutputTracks(const mkvparser::Segment& segment, const Options& options,
     const int64_t track_number = track->GetNumber();
     const wstring track_name = UTF8ToWideString(track->GetNameAsUTF8());
 
-    indent->Adjust(libwebm::kIncreaseIndent);
+    indent->Adjust(adhoc::libwebm::kIncreaseIndent);
     fprintf(o, "%sTrackType   : %" PRId64 "\n", indent->indent_str().c_str(),
             track_type);
     fprintf(o, "%sTrackNumber : %" PRId64 "\n", indent->indent_str().c_str(),
@@ -377,12 +377,12 @@ bool OutputTracks(const mkvparser::Segment& segment, const Options& options,
       fprintf(o, "%sPrivateData(size): %d\n", indent->indent_str().c_str(),
               static_cast<int>(private_size));
 
-      if (track_type == mkvparser::Track::kVideo) {
+      if (track_type == adhoc::mkvparser::Track::kVideo) {
         const std::string codec_id = ToString(track->GetCodecId());
         const std::string v_vp9 = "V_VP9";
         if (codec_id == v_vp9) {
-          libwebm::Vp9CodecFeatures features;
-          if (!libwebm::ParseVpxCodecPrivate(private_data,
+          adhoc::libwebm::Vp9CodecFeatures features;
+          if (!adhoc::libwebm::ParseVpxCodecPrivate(private_data,
                                              static_cast<int32_t>(private_size),
                                              &features)) {
             fprintf(stderr, "Error parsing VpxCodecPrivate.\n");
@@ -475,9 +475,9 @@ bool OutputTracks(const mkvparser::Segment& segment, const Options& options,
       }
     }
 
-    if (track_type == mkvparser::Track::kVideo) {
-      const mkvparser::VideoTrack* const video_track =
-          static_cast<const mkvparser::VideoTrack*>(track);
+    if (track_type == adhoc::mkvparser::Track::kVideo) {
+      const adhoc::mkvparser::VideoTrack* const video_track =
+          static_cast<const adhoc::mkvparser::VideoTrack*>(track);
       const int64_t width = video_track->GetWidth();
       const int64_t height = video_track->GetHeight();
       const int64_t display_width = video_track->GetDisplayWidth();
@@ -501,11 +501,11 @@ bool OutputTracks(const mkvparser::Segment& segment, const Options& options,
                 indent->indent_str().c_str(), display_unit);
       }
 
-      const mkvparser::Colour* const colour = video_track->GetColour();
+      const adhoc::mkvparser::Colour* const colour = video_track->GetColour();
       if (colour) {
         // TODO(fgalligan): Add support for Colour's address and size.
         fprintf(o, "%sColour:\n", indent->indent_str().c_str());
-        indent->Adjust(libwebm::kIncreaseIndent);
+        indent->Adjust(adhoc::libwebm::kIncreaseIndent);
 
         const int64_t matrix_coefficients = colour->matrix_coefficients;
         const int64_t bits_per_channel = colour->bits_per_channel;
@@ -521,58 +521,58 @@ bool OutputTracks(const mkvparser::Segment& segment, const Options& options,
         const int64_t primaries = colour->primaries;
         const int64_t max_cll = colour->max_cll;
         const int64_t max_fall = colour->max_fall;
-        if (matrix_coefficients != mkvparser::Colour::kValueNotPresent)
+        if (matrix_coefficients != adhoc::mkvparser::Colour::kValueNotPresent)
           fprintf(o, "%sMatrixCoefficients      : %" PRId64 "\n",
                   indent->indent_str().c_str(), matrix_coefficients);
-        if (bits_per_channel != mkvparser::Colour::kValueNotPresent)
+        if (bits_per_channel != adhoc::mkvparser::Colour::kValueNotPresent)
           fprintf(o, "%sBitsPerChannel          : %" PRId64 "\n",
                   indent->indent_str().c_str(), bits_per_channel);
-        if (chroma_subsampling_horz != mkvparser::Colour::kValueNotPresent)
+        if (chroma_subsampling_horz != adhoc::mkvparser::Colour::kValueNotPresent)
           fprintf(o, "%sChromaSubsamplingHorz   : %" PRId64 "\n",
                   indent->indent_str().c_str(), chroma_subsampling_horz);
-        if (chroma_subsampling_vert != mkvparser::Colour::kValueNotPresent)
+        if (chroma_subsampling_vert != adhoc::mkvparser::Colour::kValueNotPresent)
           fprintf(o, "%sChromaSubsamplingVert   : %" PRId64 "\n",
                   indent->indent_str().c_str(), chroma_subsampling_vert);
-        if (cb_subsampling_horz != mkvparser::Colour::kValueNotPresent)
+        if (cb_subsampling_horz != adhoc::mkvparser::Colour::kValueNotPresent)
           fprintf(o, "%sCbSubsamplingHorz       : %" PRId64 "\n",
                   indent->indent_str().c_str(), cb_subsampling_horz);
-        if (cb_subsampling_vert != mkvparser::Colour::kValueNotPresent)
+        if (cb_subsampling_vert != adhoc::mkvparser::Colour::kValueNotPresent)
           fprintf(o, "%sCbSubsamplingVert       : %" PRId64 "\n",
                   indent->indent_str().c_str(), cb_subsampling_vert);
-        if (chroma_siting_horz != mkvparser::Colour::kValueNotPresent)
+        if (chroma_siting_horz != adhoc::mkvparser::Colour::kValueNotPresent)
           fprintf(o, "%sChromaSitingHorz        : %" PRId64 "\n",
                   indent->indent_str().c_str(), chroma_siting_horz);
-        if (chroma_siting_vert != mkvparser::Colour::kValueNotPresent)
+        if (chroma_siting_vert != adhoc::mkvparser::Colour::kValueNotPresent)
           fprintf(o, "%sChromaSitingVert        : %" PRId64 "\n",
                   indent->indent_str().c_str(), chroma_siting_vert);
-        if (range != mkvparser::Colour::kValueNotPresent)
+        if (range != adhoc::mkvparser::Colour::kValueNotPresent)
           fprintf(o, "%sRange                   : %" PRId64 "\n",
                   indent->indent_str().c_str(), range);
-        if (transfer_characteristics != mkvparser::Colour::kValueNotPresent)
+        if (transfer_characteristics != adhoc::mkvparser::Colour::kValueNotPresent)
           fprintf(o, "%sTransferCharacteristics : %" PRId64 "\n",
                   indent->indent_str().c_str(), transfer_characteristics);
-        if (primaries != mkvparser::Colour::kValueNotPresent)
+        if (primaries != adhoc::mkvparser::Colour::kValueNotPresent)
           fprintf(o, "%sPrimaries               : %" PRId64 "\n",
                   indent->indent_str().c_str(), primaries);
-        if (max_cll != mkvparser::Colour::kValueNotPresent)
+        if (max_cll != adhoc::mkvparser::Colour::kValueNotPresent)
           fprintf(o, "%sMaxCLL                  : %" PRId64 "\n",
                   indent->indent_str().c_str(), max_cll);
-        if (max_fall != mkvparser::Colour::kValueNotPresent)
+        if (max_fall != adhoc::mkvparser::Colour::kValueNotPresent)
           fprintf(o, "%sMaxFALL                 : %" PRId64 "\n",
                   indent->indent_str().c_str(), max_fall);
 
-        const mkvparser::MasteringMetadata* const metadata =
+        const adhoc::mkvparser::MasteringMetadata* const metadata =
             colour->mastering_metadata;
         if (metadata) {
           // TODO(fgalligan): Add support for MasteringMetadata's address and
           // size.
           fprintf(o, "%sMasteringMetadata:\n", indent->indent_str().c_str());
-          indent->Adjust(libwebm::kIncreaseIndent);
+          indent->Adjust(adhoc::libwebm::kIncreaseIndent);
 
-          const mkvparser::PrimaryChromaticity* const red = metadata->r;
-          const mkvparser::PrimaryChromaticity* const green = metadata->g;
-          const mkvparser::PrimaryChromaticity* const blue = metadata->b;
-          const mkvparser::PrimaryChromaticity* const white =
+          const adhoc::mkvparser::PrimaryChromaticity* const red = metadata->r;
+          const adhoc::mkvparser::PrimaryChromaticity* const green = metadata->g;
+          const adhoc::mkvparser::PrimaryChromaticity* const blue = metadata->b;
+          const adhoc::mkvparser::PrimaryChromaticity* const white =
               metadata->white_point;
           const float max = metadata->luminance_max;
           const float min = metadata->luminance_min;
@@ -600,27 +600,27 @@ bool OutputTracks(const mkvparser::Segment& segment, const Options& options,
             fprintf(o, "%sWhitePointChromaticityY : %g\n",
                     indent->indent_str().c_str(), white->y);
           }
-          if (max != mkvparser::MasteringMetadata::kValueNotPresent)
+          if (max != adhoc::mkvparser::MasteringMetadata::kValueNotPresent)
             fprintf(o, "%sLuminanceMax            : %g\n",
                     indent->indent_str().c_str(), max);
-          if (min != mkvparser::MasteringMetadata::kValueNotPresent)
+          if (min != adhoc::mkvparser::MasteringMetadata::kValueNotPresent)
             fprintf(o, "%sLuminanceMin            : %g\n",
                     indent->indent_str().c_str(), min);
-          indent->Adjust(libwebm::kDecreaseIndent);
+          indent->Adjust(adhoc::libwebm::kDecreaseIndent);
         }
-        indent->Adjust(libwebm::kDecreaseIndent);
+        indent->Adjust(adhoc::libwebm::kDecreaseIndent);
       }
 
-      const mkvparser::Projection* const projection =
+      const adhoc::mkvparser::Projection* const projection =
           video_track->GetProjection();
       if (projection) {
         fprintf(o, "%sProjection:\n", indent->indent_str().c_str());
-        indent->Adjust(libwebm::kIncreaseIndent);
+        indent->Adjust(adhoc::libwebm::kIncreaseIndent);
 
         const int projection_type = static_cast<int>(projection->type);
         const int kTypeNotPresent =
-            static_cast<int>(mkvparser::Projection::kTypeNotPresent);
-        const float kValueNotPresent = mkvparser::Projection::kValueNotPresent;
+            static_cast<int>(adhoc::mkvparser::Projection::kTypeNotPresent);
+        const float kValueNotPresent = adhoc::mkvparser::Projection::kValueNotPresent;
         if (projection_type != kTypeNotPresent)
           fprintf(o, "%sProjectionType            : %d\n",
                   indent->indent_str().c_str(), projection_type);
@@ -637,11 +637,11 @@ bool OutputTracks(const mkvparser::Segment& segment, const Options& options,
         if (projection->pose_roll != kValueNotPresent)
           fprintf(o, "%sProjectionPoseRoll         : %g\n",
                   indent->indent_str().c_str(), projection->pose_roll);
-        indent->Adjust(libwebm::kDecreaseIndent);
+        indent->Adjust(adhoc::libwebm::kDecreaseIndent);
       }
-    } else if (track_type == mkvparser::Track::kAudio) {
-      const mkvparser::AudioTrack* const audio_track =
-          static_cast<const mkvparser::AudioTrack*>(track);
+    } else if (track_type == adhoc::mkvparser::Track::kAudio) {
+      const adhoc::mkvparser::AudioTrack* const audio_track =
+          static_cast<const adhoc::mkvparser::AudioTrack*>(track);
       const int64_t channels = audio_track->GetChannels();
       const int64_t bit_depth = audio_track->GetBitDepth();
       const uint64_t codec_delay = audio_track->GetCodecDelay();
@@ -660,7 +660,7 @@ bool OutputTracks(const mkvparser::Segment& segment, const Options& options,
         fprintf(o, "%sSeekPreRoll      : %" PRIu64 "\n",
                 indent->indent_str().c_str(), seek_preroll);
     }
-    indent->Adjust(libwebm::kDecreaseIndent * 2);
+    indent->Adjust(adhoc::libwebm::kDecreaseIndent * 2);
   }
 
   return true;
@@ -695,8 +695,8 @@ void ParseSuperframeIndex(const uint8_t* data, size_t data_sz,
 }
 
 void PrintVP9Info(const uint8_t* data, int size, FILE* o, int64_t time_ns,
-                  FrameStats* stats, vp9_parser::Vp9HeaderParser* parser,
-                  vp9_parser::Vp9LevelStats* level_stats) {
+                  FrameStats* stats, adhoc::vp9_parser::Vp9HeaderParser* parser,
+                  adhoc::vp9_parser::Vp9LevelStats* level_stats) {
   if (size < 1)
     return;
 
@@ -829,7 +829,7 @@ int PrintSubSampleEncryption(const uint8_t* data, int size, FILE* o) {
       return 0;
     uint32_t partition_offset;
     memcpy(&partition_offset, data, sizeof(partition_offset));
-    partition_offset = libwebm::bigendian_to_host(partition_offset);
+    partition_offset = adhoc::libwebm::bigendian_to_host(partition_offset);
     fprintf(o, " off[%d]:%u", i, partition_offset);
     data += sizeof(uint32_t);
   }
@@ -837,15 +837,15 @@ int PrintSubSampleEncryption(const uint8_t* data, int size, FILE* o) {
   return read_end;
 }
 
-bool OutputCluster(const mkvparser::Cluster& cluster,
-                   const mkvparser::Tracks& tracks, const Options& options,
-                   FILE* o, mkvparser::MkvReader* reader, Indent* indent,
+bool OutputCluster(const adhoc::mkvparser::Cluster& cluster,
+                   const adhoc::mkvparser::Tracks& tracks, const Options& options,
+                   FILE* o, adhoc::mkvparser::MkvReader* reader, Indent* indent,
                    int64_t* clusters_size, FrameStats* stats,
-                   vp9_parser::Vp9HeaderParser* parser,
-                   vp9_parser::Vp9LevelStats* level_stats) {
+                   adhoc::vp9_parser::Vp9HeaderParser* parser,
+                   adhoc::vp9_parser::Vp9LevelStats* level_stats) {
   if (clusters_size) {
     // Load the Cluster.
-    const mkvparser::BlockEntry* block_entry;
+    const adhoc::mkvparser::BlockEntry* block_entry;
     long status = cluster.GetFirst(block_entry);
     if (status) {
       fprintf(stderr, "Could not get first Block of Cluster.\n");
@@ -865,7 +865,7 @@ bool OutputCluster(const mkvparser::Cluster& cluster,
     if (options.output_size)
       fprintf(o, "  size: %lld", cluster.GetElementSize());
     fprintf(o, "\n");
-    indent->Adjust(libwebm::kIncreaseIndent);
+    indent->Adjust(adhoc::libwebm::kIncreaseIndent);
     if (options.output_seconds)
       fprintf(o, "%sTimecode (sec) : %g\n", indent->indent_str().c_str(),
               time_ns / kNanosecondsPerSecond);
@@ -884,7 +884,7 @@ bool OutputCluster(const mkvparser::Cluster& cluster,
   }
 
   if (options.output_blocks) {
-    const mkvparser::BlockEntry* block_entry;
+    const adhoc::mkvparser::BlockEntry* block_entry;
     long status = cluster.GetFirst(block_entry);
     if (status) {
       fprintf(stderr, "Could not get first Block of Cluster.\n");
@@ -893,7 +893,7 @@ bool OutputCluster(const mkvparser::Cluster& cluster,
 
     std::vector<unsigned char> vector_data;
     while (block_entry != NULL && !block_entry->EOS()) {
-      const mkvparser::Block* const block = block_entry->GetBlock();
+      const adhoc::mkvparser::Block* const block = block_entry->GetBlock();
       if (!block) {
         fprintf(stderr, "Could not getblock entry.\n");
         return false;
@@ -901,25 +901,25 @@ bool OutputCluster(const mkvparser::Cluster& cluster,
 
       const unsigned int track_number =
           static_cast<unsigned int>(block->GetTrackNumber());
-      const mkvparser::Track* track = tracks.GetTrackByNumber(track_number);
+      const adhoc::mkvparser::Track* track = tracks.GetTrackByNumber(track_number);
       if (!track) {
         fprintf(stderr, "Could not get Track.\n");
         return false;
       }
 
       const int64_t track_type = track->GetType();
-      if ((track_type == mkvparser::Track::kVideo && options.output_video) ||
-          (track_type == mkvparser::Track::kAudio && options.output_audio)) {
+      if ((track_type == adhoc::mkvparser::Track::kVideo && options.output_video) ||
+          (track_type == adhoc::mkvparser::Track::kAudio && options.output_audio)) {
         const int64_t time_ns = block->GetTime(&cluster);
         const bool is_key = block->IsKey();
 
-        if (block_entry->GetKind() == mkvparser::BlockEntry::kBlockGroup) {
+        if (block_entry->GetKind() == adhoc::mkvparser::BlockEntry::kBlockGroup) {
           fprintf(o, "%sBlockGroup:\n", indent->indent_str().c_str());
-          indent->Adjust(libwebm::kIncreaseIndent);
+          indent->Adjust(adhoc::libwebm::kIncreaseIndent);
         }
 
         fprintf(o, "%sBlock: type:%s frame:%s", indent->indent_str().c_str(),
-                track_type == mkvparser::Track::kVideo ? "V" : "A",
+                track_type == adhoc::mkvparser::Track::kVideo ? "V" : "A",
                 is_key ? "I" : "P");
         if (options.output_seconds)
           fprintf(o, " secs:%5g", time_ns / kNanosecondsPerSecond);
@@ -956,7 +956,7 @@ bool OutputCluster(const mkvparser::Cluster& cluster,
           }
 
           if (encrypted_stream) {
-            const mkvparser::Block::Frame& frame = block->GetFrame(0);
+            const adhoc::mkvparser::Block::Frame& frame = block->GetFrame(0);
             if (frame.len > static_cast<int>(vector_data.size())) {
               vector_data.resize(frame.len + 1024);
             }
@@ -985,12 +985,12 @@ bool OutputCluster(const mkvparser::Cluster& cluster,
 
           if (frame_count > 1) {
             fprintf(o, "\n");
-            indent->Adjust(libwebm::kIncreaseIndent);
+            indent->Adjust(adhoc::libwebm::kIncreaseIndent);
           }
 
           for (int i = 0; i < frame_count; ++i) {
-            if (track_type == mkvparser::Track::kVideo) {
-              const mkvparser::Block::Frame& frame = block->GetFrame(i);
+            if (track_type == adhoc::mkvparser::Track::kVideo) {
+              const adhoc::mkvparser::Block::Frame& frame = block->GetFrame(i);
               if (frame.len > static_cast<int>(vector_data.size())) {
                 vector_data.resize(frame.len + 1024);
               }
@@ -1040,16 +1040,16 @@ bool OutputCluster(const mkvparser::Cluster& cluster,
           }
 
           if (frame_count > 1)
-            indent->Adjust(libwebm::kDecreaseIndent);
+            indent->Adjust(adhoc::libwebm::kDecreaseIndent);
         }
 
-        if (block_entry->GetKind() == mkvparser::BlockEntry::kBlockGroup) {
+        if (block_entry->GetKind() == adhoc::mkvparser::BlockEntry::kBlockGroup) {
           const int64_t discard_padding = block->GetDiscardPadding();
           if (discard_padding != 0) {
             fprintf(o, "\n%sDiscardPadding: %10" PRId64,
                     indent->indent_str().c_str(), discard_padding);
           }
-          indent->Adjust(libwebm::kDecreaseIndent);
+          indent->Adjust(adhoc::libwebm::kDecreaseIndent);
         }
 
         fprintf(o, "\n");
@@ -1064,15 +1064,15 @@ bool OutputCluster(const mkvparser::Cluster& cluster,
   }
 
   if (options.output_clusters)
-    indent->Adjust(libwebm::kDecreaseIndent);
+    indent->Adjust(adhoc::libwebm::kDecreaseIndent);
 
   return true;
 }
 
-bool OutputCues(const mkvparser::Segment& segment,
-                const mkvparser::Tracks& tracks, const Options& options,
+bool OutputCues(const adhoc::mkvparser::Segment& segment,
+                const adhoc::mkvparser::Tracks& tracks, const Options& options,
                 FILE* o, Indent* indent) {
-  const mkvparser::Cues* const cues = segment.GetCues();
+  const adhoc::mkvparser::Cues* const cues = segment.GetCues();
   if (cues == NULL)
     return true;
 
@@ -1081,7 +1081,7 @@ bool OutputCues(const mkvparser::Segment& segment,
     cues->LoadCuePoint();
 
   // Confirm that the input has cue points.
-  const mkvparser::CuePoint* const first_cue = cues->GetFirst();
+  const adhoc::mkvparser::CuePoint* const first_cue = cues->GetFirst();
   if (first_cue == NULL) {
     fprintf(o, "%sNo cue points.\n", indent->indent_str().c_str());
     return true;
@@ -1095,20 +1095,20 @@ bool OutputCues(const mkvparser::Segment& segment,
     fprintf(o, " size:%lld", cues->m_element_size);
   fprintf(o, "\n");
 
-  const mkvparser::CuePoint* cue_point = first_cue;
+  const adhoc::mkvparser::CuePoint* cue_point = first_cue;
   int cue_point_num = 1;
   const int num_tracks = static_cast<int>(tracks.GetTracksCount());
-  indent->Adjust(libwebm::kIncreaseIndent);
+  indent->Adjust(adhoc::libwebm::kIncreaseIndent);
 
   do {
     for (int track_num = 0; track_num < num_tracks; ++track_num) {
-      const mkvparser::Track* const track = tracks.GetTrackByIndex(track_num);
-      const mkvparser::CuePoint::TrackPosition* const track_pos =
+      const adhoc::mkvparser::Track* const track = tracks.GetTrackByIndex(track_num);
+      const adhoc::mkvparser::CuePoint::TrackPosition* const track_pos =
           cue_point->Find(track);
 
       if (track_pos != NULL) {
         const char track_type =
-            (track->GetType() == mkvparser::Track::kVideo) ? 'V' : 'A';
+            (track->GetType() == adhoc::mkvparser::Track::kVideo) ? 'V' : 'A';
         fprintf(o, "%sCue Point:%d type:%c track:%d",
                 indent->indent_str().c_str(), cue_point_num, track_type,
                 static_cast<int>(track->GetNumber()));
@@ -1134,7 +1134,7 @@ bool OutputCues(const mkvparser::Segment& segment,
     ++cue_point_num;
   } while (cue_point != NULL);
 
-  indent->Adjust(libwebm::kDecreaseIndent);
+  indent->Adjust(adhoc::libwebm::kDecreaseIndent);
   return true;
 }
 
@@ -1199,16 +1199,16 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  std::unique_ptr<mkvparser::MkvReader> reader(
-      new (std::nothrow) mkvparser::MkvReader());  // NOLINT
+  std::unique_ptr<adhoc::mkvparser::MkvReader> reader(
+      new (std::nothrow) adhoc::mkvparser::MkvReader());  // NOLINT
   if (reader->Open(input.c_str())) {
     fprintf(stderr, "Error opening file:%s\n", input.c_str());
     return EXIT_FAILURE;
   }
 
   long long int pos = 0;
-  std::unique_ptr<mkvparser::EBMLHeader> ebml_header(
-      new (std::nothrow) mkvparser::EBMLHeader());  // NOLINT
+  std::unique_ptr<adhoc::mkvparser::EBMLHeader> ebml_header(
+      new (std::nothrow) adhoc::mkvparser::EBMLHeader());  // NOLINT
   if (ebml_header->Parse(reader.get(), pos) < 0) {
     fprintf(stderr, "Error parsing EBML header.\n");
     return EXIT_FAILURE;
@@ -1220,12 +1220,12 @@ int main(int argc, char* argv[]) {
   if (options.output_ebml_header)
     OutputEBMLHeader(*ebml_header.get(), out, &indent);
 
-  mkvparser::Segment* temp_segment;
-  if (mkvparser::Segment::CreateInstance(reader.get(), pos, temp_segment)) {
+  adhoc::mkvparser::Segment* temp_segment;
+  if (adhoc::mkvparser::Segment::CreateInstance(reader.get(), pos, temp_segment)) {
     fprintf(stderr, "Segment::CreateInstance() failed.\n");
     return EXIT_FAILURE;
   }
-  std::unique_ptr<mkvparser::Segment> segment(temp_segment);
+  std::unique_ptr<adhoc::mkvparser::Segment> segment(temp_segment);
 
   if (segment->Load() < 0) {
     fprintf(stderr, "Segment::Load() failed.\n");
@@ -1234,7 +1234,7 @@ int main(int argc, char* argv[]) {
 
   if (options.output_segment) {
     OutputSegment(*(segment.get()), options, out);
-    indent.Adjust(libwebm::kIncreaseIndent);
+    indent.Adjust(adhoc::libwebm::kIncreaseIndent);
   }
 
   if (options.output_seekhead)
@@ -1249,7 +1249,7 @@ int main(int argc, char* argv[]) {
     if (!OutputTracks(*(segment.get()), options, out, &indent))
       return EXIT_FAILURE;
 
-  const mkvparser::Tracks* const tracks = segment->GetTracks();
+  const adhoc::mkvparser::Tracks* const tracks = segment->GetTracks();
   if (!tracks) {
     fprintf(stderr, "Could not get Tracks.\n");
     return EXIT_FAILURE;
@@ -1257,8 +1257,8 @@ int main(int argc, char* argv[]) {
 
   // If Cues are before the clusters output them first.
   if (options.output_cues) {
-    const mkvparser::Cluster* cluster = segment->GetFirst();
-    const mkvparser::Cues* const cues = segment->GetCues();
+    const adhoc::mkvparser::Cluster* cluster = segment->GetFirst();
+    const adhoc::mkvparser::Cues* const cues = segment->GetCues();
     if (cluster != NULL && cues != NULL) {
       if (cues->m_element_start < cluster->m_element_start) {
         if (!OutputCues(*segment, *tracks, options, out, &indent)) {
@@ -1275,9 +1275,9 @@ int main(int argc, char* argv[]) {
 
   int64_t clusters_size = 0;
   FrameStats stats;
-  vp9_parser::Vp9HeaderParser parser;
-  vp9_parser::Vp9LevelStats level_stats;
-  const mkvparser::Cluster* cluster = segment->GetFirst();
+  adhoc::vp9_parser::Vp9HeaderParser parser;
+  adhoc::vp9_parser::Vp9LevelStats level_stats;
+  const adhoc::mkvparser::Cluster* cluster = segment->GetFirst();
   while (cluster != NULL && !cluster->EOS()) {
     if (!OutputCluster(*cluster, *tracks, options, out, reader.get(), &indent,
                        &clusters_size, &stats, &parser, &level_stats))
@@ -1319,7 +1319,7 @@ int main(int argc, char* argv[]) {
 
   if (options.output_vp9_level) {
     level_stats.set_duration(segment->GetInfo()->GetDuration());
-    const vp9_parser::Vp9Level level = level_stats.GetLevel();
+    const adhoc::vp9_parser::Vp9Level level = level_stats.GetLevel();
     fprintf(out, "VP9 Level:%d\n", level);
     fprintf(
         out,

--- a/webm_parser/README.md
+++ b/webm_parser/README.md
@@ -205,9 +205,9 @@ stdin:
 #include <webm/webm_parser.h>
 
 int main() {
-  webm::Callback callback;
-  webm::FileReader reader(std::freopen(nullptr, "rb", stdin));
-  webm::WebmParser parser;
+  adhoc::webm::Callback callback;
+  adhoc::webm::FileReader reader(std::freopen(nullptr, "rb", stdin));
+  adhoc::webm::WebmParser parser;
   parser.Feed(&callback, &reader);
 }
 ```
@@ -225,15 +225,15 @@ change it to:
 #include <webm/status.h>
 #include <webm/webm_parser.h>
 
-class MyCallback : public webm::Callback {
+class MyCallback : public adhoc::webm::Callback {
  public:
-  webm::Status OnElementBegin(const webm::ElementMetadata& metadata,
-                              webm::Action* action) override {
+  adhoc::webm::Status OnElementBegin(const adhoc::webm::ElementMetadata& metadata,
+                              adhoc::webm::Action* action) override {
     std::cout << "Element ID = 0x"
               << std::hex << static_cast<std::uint32_t>(metadata.id);
     std::cout << std::dec;  // Reset to decimal mode.
     std::cout << " at position ";
-    if (metadata.position == webm::kUnknownElementPosition) {
+    if (metadata.position == adhoc::webm::kUnknownElementPosition) {
       // The position will only be unknown if we've done a seek. But since we
       // aren't seeking in this demo, this will never be the case. However, this
       // if-statement is included for completeness.
@@ -242,7 +242,7 @@ class MyCallback : public webm::Callback {
       std::cout << metadata.position;
     }
     std::cout << " with header size ";
-    if (metadata.header_size == webm::kUnknownHeaderSize) {
+    if (metadata.header_size == adhoc::webm::kUnknownHeaderSize) {
       // The header size will only be unknown if we've done a seek. But since we
       // aren't seeking in this demo, this will never be the case. However, this
       // if-statement is included for completeness.
@@ -251,7 +251,7 @@ class MyCallback : public webm::Callback {
       std::cout << metadata.header_size;
     }
     std::cout << " and body size ";
-    if (metadata.size == webm::kUnknownElementSize) {
+    if (metadata.size == adhoc::webm::kUnknownElementSize) {
       // WebM master elements may have an unknown size, though this is rare.
       std::cout << "<unknown>";
     } else {
@@ -259,16 +259,16 @@ class MyCallback : public webm::Callback {
     }
     std::cout << '\n';
 
-    *action = webm::Action::kRead;
-    return webm::Status(webm::Status::kOkCompleted);
+    *action = adhoc::webm::Action::kRead;
+    return adhoc::webm::Status(adhoc::webm::Status::kOkCompleted);
   }
 };
 
 int main() {
   MyCallback callback;
-  webm::FileReader reader(std::freopen(nullptr, "rb", stdin));
-  webm::WebmParser parser;
-  webm::Status status = parser.Feed(&callback, &reader);
+  adhoc::webm::FileReader reader(std::freopen(nullptr, "rb", stdin));
+  adhoc::webm::WebmParser parser;
+  adhoc::webm::Status status = parser.Feed(&callback, &reader);
   if (status.completed_ok()) {
     std::cout << "Parsing successfully completed\n";
   } else {

--- a/webm_parser/fuzzing/webm_fuzzer.cc
+++ b/webm_parser/fuzzing/webm_fuzzer.cc
@@ -20,12 +20,12 @@
 #include "webm/status.h"
 #include "webm/webm_parser.h"
 
-using webm::BufferReader;
-using webm::Callback;
-using webm::FileReader;
-using webm::Reader;
-using webm::Status;
-using webm::WebmParser;
+using adhoc::webm::BufferReader;
+using adhoc::webm::Callback;
+using adhoc::webm::FileReader;
+using adhoc::webm::Reader;
+using adhoc::webm::Status;
+using adhoc::webm::WebmParser;
 
 static int Run(Reader* reader) {
   Callback callback;

--- a/webm_parser/include/webm/buffer_reader.h
+++ b/webm_parser/include/webm/buffer_reader.h
@@ -21,7 +21,7 @@
  A `Reader` implementation that reads from a `std::vector<std::uint8_t>`.
  */
 
-namespace webm {
+namespace adhoc::webm {
 
 /**
  \addtogroup PUBLIC_API
@@ -133,6 +133,5 @@ class BufferReader : public Reader {
  @}
  */
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // INCLUDE_WEBM_BUFFER_READER_H_

--- a/webm_parser/include/webm/callback.h
+++ b/webm_parser/include/webm/callback.h
@@ -19,7 +19,7 @@
  The main callback type that receives parsing events.
  */
 
-namespace webm {
+namespace adhoc::webm {
 
 /**
  \addtogroup PUBLIC_API
@@ -358,6 +358,5 @@ class Callback {
  @}
  */
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // INCLUDE_WEBM_CALLBACK_H_

--- a/webm_parser/include/webm/dom_types.h
+++ b/webm_parser/include/webm/dom_types.h
@@ -23,7 +23,7 @@
  the element that each type/member represents.
  */
 
-namespace webm {
+namespace adhoc::webm {
 
 /**
  \addtogroup PUBLIC_API
@@ -1776,6 +1776,5 @@ struct Tag {
  @}
  */
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // INCLUDE_WEBM_DOM_TYPES_H_

--- a/webm_parser/include/webm/element.h
+++ b/webm_parser/include/webm/element.h
@@ -20,7 +20,7 @@
  metadata.
  */
 
-namespace webm {
+namespace adhoc::webm {
 
 /**
  \addtogroup PUBLIC_API
@@ -203,6 +203,5 @@ constexpr std::uint64_t kUnknownElementPosition =
  @}
  */
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // INCLUDE_WEBM_ELEMENT_H_

--- a/webm_parser/include/webm/file_reader.h
+++ b/webm_parser/include/webm/file_reader.h
@@ -21,7 +21,7 @@
  A `Reader` implementation that reads from a `FILE*`.
  */
 
-namespace webm {
+namespace adhoc::webm {
 
 /**
  A `Reader` implementation that can read from `FILE*` resources.
@@ -98,6 +98,5 @@ class FileReader : public Reader {
   std::uint64_t position_ = 0;
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // INCLUDE_WEBM_FILE_READER_H_

--- a/webm_parser/include/webm/id.h
+++ b/webm_parser/include/webm/id.h
@@ -15,7 +15,7 @@
  A full enumeration of WebM's EBML IDs.
  */
 
-namespace webm {
+namespace adhoc::webm {
 
 /**
  \addtogroup PUBLIC_API

--- a/webm_parser/include/webm/istream_reader.h
+++ b/webm_parser/include/webm/istream_reader.h
@@ -22,7 +22,7 @@
  A `Reader` implementation that reads from a `std::istream`.
  */
 
-namespace webm {
+namespace adhoc::webm {
 
 /**
  A `Reader` implementation that can read from `std::istream`-based resources.
@@ -94,6 +94,5 @@ class IstreamReader : public Reader {
   std::uint64_t position_ = 0;
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // INCLUDE_WEBM_ISTREAM_READER_H_

--- a/webm_parser/include/webm/reader.h
+++ b/webm_parser/include/webm/reader.h
@@ -18,7 +18,7 @@
  An interface that acts as a data source for the parser to read from.
  */
 
-namespace webm {
+namespace adhoc::webm {
 
 /**
  \addtogroup PUBLIC_API
@@ -89,6 +89,5 @@ class Reader {
  @}
  */
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // INCLUDE_WEBM_READER_H_

--- a/webm_parser/include/webm/status.h
+++ b/webm_parser/include/webm/status.h
@@ -16,7 +16,7 @@
  throughout the API.
  */
 
-namespace webm {
+namespace adhoc::webm {
 
 /**
  \addtogroup PUBLIC_API
@@ -161,6 +161,5 @@ struct Status {
  @}
  */
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // INCLUDE_WEBM_STATUS_H_

--- a/webm_parser/include/webm/webm_parser.h
+++ b/webm_parser/include/webm/webm_parser.h
@@ -19,7 +19,7 @@
  The main parser class for parsing WebM files.
  */
 
-namespace webm {
+namespace adhoc::webm {
 
 /**
  \defgroup PUBLIC_API Public API
@@ -128,6 +128,5 @@ void swap(WebmParser& left, WebmParser& right);
  @}
  */
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // INCLUDE_WEBM_WEBM_PARSER_H_

--- a/webm_parser/src/ancestory.cc
+++ b/webm_parser/src/ancestory.cc
@@ -9,7 +9,7 @@
 
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 bool Ancestory::ById(Id id, Ancestory* ancestory) {
   // These lists of IDs were generated and must match the switch statement and
@@ -331,4 +331,4 @@ bool Ancestory::ById(Id id, Ancestory* ancestory) {
   }
 }
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/ancestory.h
+++ b/webm_parser/src/ancestory.h
@@ -14,7 +14,7 @@
 
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Represents an element's ancestory in descending order. For example, the
 // Id::kTrackNumber element has an ancestory of {Id::kSegment, Id::kTracks,
@@ -78,6 +78,5 @@ class Ancestory {
   const Id* end_ = nullptr;
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_ANCESTORY_H_

--- a/webm_parser/src/audio_parser.h
+++ b/webm_parser/src/audio_parser.h
@@ -20,7 +20,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#Audio
@@ -79,6 +79,5 @@ class AudioParser : public MasterValueParser<Audio> {
   }
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_AUDIO_PARSER_H_

--- a/webm_parser/src/bit_utils.cc
+++ b/webm_parser/src/bit_utils.cc
@@ -9,7 +9,7 @@
 
 #include <cstdint>
 
-namespace webm {
+namespace adhoc::webm {
 
 std::uint8_t CountLeadingZeros(std::uint8_t value) {
   // Special case for 0 since we can't shift by sizeof(T) * 8 bytes.
@@ -23,4 +23,4 @@ std::uint8_t CountLeadingZeros(std::uint8_t value) {
   return count;
 }
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/bit_utils.h
+++ b/webm_parser/src/bit_utils.h
@@ -10,7 +10,7 @@
 
 #include <cstdint>
 
-namespace webm {
+namespace adhoc::webm {
 
 // Counts the number of leading zero bits.
 // For example:
@@ -19,6 +19,5 @@ namespace webm {
 //   assert(0 == CountLeadingZeros(0xf0));
 std::uint8_t CountLeadingZeros(std::uint8_t value);
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_BIT_UTILS_H_

--- a/webm_parser/src/block_additions_parser.h
+++ b/webm_parser/src/block_additions_parser.h
@@ -13,7 +13,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#BlockAdditions
@@ -25,6 +25,5 @@ class BlockAdditionsParser : public MasterValueParser<BlockAdditions> {
             Id::kBlockMore, &BlockAdditions::block_mores)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_BLOCK_ADDITIONS_PARSER_H_

--- a/webm_parser/src/block_group_parser.h
+++ b/webm_parser/src/block_group_parser.h
@@ -17,7 +17,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#BlockGroup

--- a/webm_parser/src/block_header_parser.cc
+++ b/webm_parser/src/block_header_parser.cc
@@ -12,7 +12,7 @@
 
 #include "src/parser_utils.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#block_structure
@@ -73,4 +73,4 @@ Status BlockHeaderParser::Feed(Callback* callback, Reader* reader,
   }
 }
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/block_header_parser.h
+++ b/webm_parser/src/block_header_parser.h
@@ -17,7 +17,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 struct BlockHeader {
   std::uint64_t track_number;
@@ -60,6 +60,5 @@ class BlockHeaderParser : public Parser {
   } state_ = State::kReadingTrackNumber;
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_BLOCK_HEADER_PARSER_H_

--- a/webm_parser/src/block_more_parser.h
+++ b/webm_parser/src/block_more_parser.h
@@ -14,7 +14,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#BlockMore
@@ -27,6 +27,5 @@ class BlockMoreParser : public MasterValueParser<BlockMore> {
             MakeChild<BinaryParser>(Id::kBlockAdditional, &BlockMore::data)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_BLOCK_MORE_PARSER_H_

--- a/webm_parser/src/block_parser.cc
+++ b/webm_parser/src/block_parser.cc
@@ -16,7 +16,7 @@
 #include "src/parser_utils.h"
 #include "webm/element.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 namespace {
 
@@ -282,4 +282,4 @@ bool BasicBlockParser<T>::WasSkipped() const {
 template class BasicBlockParser<Block>;
 template class BasicBlockParser<SimpleBlock>;
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/block_parser.h
+++ b/webm_parser/src/block_parser.h
@@ -22,7 +22,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Parses Block and SimpleBlock elements. It is recommended to use the
 // BlockParser and SimpleBlockParser aliases.
@@ -121,6 +121,5 @@ extern template class BasicBlockParser<SimpleBlock>;
 using BlockParser = BasicBlockParser<Block>;
 using SimpleBlockParser = BasicBlockParser<SimpleBlock>;
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_BLOCK_PARSER_H_

--- a/webm_parser/src/bool_parser.h
+++ b/webm_parser/src/bool_parser.h
@@ -18,7 +18,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Parses a boolean from a byte stream. EBML does not have a boolean type, but
 // the Matroska spec defines some unsigned integer elements that have a range of
@@ -90,6 +90,5 @@ class BoolParser : public ElementParser {
   int size_;
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_BOOL_PARSER_H_

--- a/webm_parser/src/buffer_reader.cc
+++ b/webm_parser/src/buffer_reader.cc
@@ -17,7 +17,7 @@
 
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 BufferReader::BufferReader(std::initializer_list<std::uint8_t> bytes)
     : data_(bytes) {}
@@ -107,4 +107,4 @@ Status BufferReader::Skip(std::uint64_t num_to_skip,
 
 std::uint64_t BufferReader::Position() const { return pos_; }
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/byte_parser.h
+++ b/webm_parser/src/byte_parser.h
@@ -20,7 +20,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Parses an EBML string (UTF-8 and ASCII) or binary element from a byte stream.
 // Spec reference for string/binary elements:
@@ -139,6 +139,5 @@ class ByteParser : public ElementParser {
 using StringParser = ByteParser<std::string>;
 using BinaryParser = ByteParser<std::vector<std::uint8_t>>;
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_BYTE_PARSER_H_

--- a/webm_parser/src/callback.cc
+++ b/webm_parser/src/callback.cc
@@ -9,7 +9,7 @@
 
 #include <cassert>
 
-namespace webm {
+namespace adhoc::webm {
 
 Status Callback::OnElementBegin(const ElementMetadata& /* metadata */,
                                 Action* action) {
@@ -152,4 +152,4 @@ Status Callback::Skip(Reader* reader, std::uint64_t* bytes_remaining) {
   return status;
 }
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/chapter_atom_parser.h
+++ b/webm_parser/src/chapter_atom_parser.h
@@ -15,7 +15,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#ChapterAtom
@@ -37,6 +37,5 @@ class ChapterAtomParser : public MasterValueParser<ChapterAtom> {
                                          max_recursive_depth)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_CHAPTER_ATOM_PARSER_H_

--- a/webm_parser/src/chapter_display_parser.h
+++ b/webm_parser/src/chapter_display_parser.h
@@ -13,7 +13,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#ChapterDisplay
@@ -29,6 +29,5 @@ class ChapterDisplayParser : public MasterValueParser<ChapterDisplay> {
                                     &ChapterDisplay::countries)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_CHAPTER_DISPLAY_PARSER_H_

--- a/webm_parser/src/chapters_parser.h
+++ b/webm_parser/src/chapters_parser.h
@@ -12,7 +12,7 @@
 #include "src/master_parser.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#Chapters
@@ -23,6 +23,5 @@ class ChaptersParser : public MasterParser {
       : MasterParser(MakeChild<EditionEntryParser>(Id::kEditionEntry)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_CHAPTERS_PARSER_H_

--- a/webm_parser/src/cluster_parser.h
+++ b/webm_parser/src/cluster_parser.h
@@ -15,7 +15,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#Cluster
@@ -43,6 +43,5 @@ class ClusterParser : public MasterValueParser<Cluster> {
   }
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_CLUSTER_PARSER_H_

--- a/webm_parser/src/colour_parser.h
+++ b/webm_parser/src/colour_parser.h
@@ -14,7 +14,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#Colour
@@ -50,6 +50,5 @@ class ColourParser : public MasterValueParser<Colour> {
                                                &Colour::mastering_metadata)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_COLOUR_PARSER_H_

--- a/webm_parser/src/content_enc_aes_settings_parser.h
+++ b/webm_parser/src/content_enc_aes_settings_parser.h
@@ -13,7 +13,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://www.webmproject.org/docs/webm-encryption/#42-new-matroskawebm-elements
@@ -27,6 +27,5 @@ class ContentEncAesSettingsParser
                 &ContentEncAesSettings::aes_settings_cipher_mode)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_CONTENT_ENC_AES_SETTINGS_PARSER_H_

--- a/webm_parser/src/content_encoding_parser.h
+++ b/webm_parser/src/content_encoding_parser.h
@@ -14,7 +14,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#ContentEncoding
@@ -33,6 +33,5 @@ class ContentEncodingParser : public MasterValueParser<ContentEncoding> {
                                                &ContentEncoding::encryption)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_CONTENT_ENCODING_PARSER_H_

--- a/webm_parser/src/content_encodings_parser.h
+++ b/webm_parser/src/content_encodings_parser.h
@@ -13,7 +13,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#ContentEncodings
@@ -25,6 +25,5 @@ class ContentEncodingsParser : public MasterValueParser<ContentEncodings> {
             Id::kContentEncoding, &ContentEncodings::encodings)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_CONTENT_ENCODINGS_PARSER_H_

--- a/webm_parser/src/content_encryption_parser.h
+++ b/webm_parser/src/content_encryption_parser.h
@@ -14,7 +14,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#ContentEncryption
@@ -32,6 +32,5 @@ class ContentEncryptionParser : public MasterValueParser<ContentEncryption> {
   }
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_CONTENT_ENCRYPTION_PARSER_H_

--- a/webm_parser/src/cue_point_parser.h
+++ b/webm_parser/src/cue_point_parser.h
@@ -14,7 +14,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#CuePoint
@@ -33,6 +33,5 @@ class CuePointParser : public MasterValueParser<CuePoint> {
   }
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_CUE_POINT_PARSER_H_

--- a/webm_parser/src/cue_track_positions_parser.h
+++ b/webm_parser/src/cue_track_positions_parser.h
@@ -13,7 +13,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#CueTrackPositions
@@ -34,6 +34,5 @@ class CueTrackPositionsParser : public MasterValueParser<CueTrackPositions> {
                                          &CueTrackPositions::block_number)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_CUE_TRACK_POSITIONS_PARSER_H_

--- a/webm_parser/src/cues_parser.h
+++ b/webm_parser/src/cues_parser.h
@@ -12,7 +12,7 @@
 #include "src/master_parser.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#Cues
@@ -22,6 +22,5 @@ class CuesParser : public MasterParser {
   CuesParser() : MasterParser(MakeChild<CuePointParser>(Id::kCuePoint)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_CUES_PARSER_H_

--- a/webm_parser/src/date_parser.cc
+++ b/webm_parser/src/date_parser.cc
@@ -16,7 +16,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#EBML_ex
@@ -69,4 +69,4 @@ Status DateParser::Feed(Callback* callback, Reader* reader,
   return status;
 }
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/date_parser.h
+++ b/webm_parser/src/date_parser.h
@@ -17,7 +17,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Parses an EBML date from a byte stream. EBML dates are signed integer values
 // that represent the offset, in nanoseconds, from 2001-01-01T00:00:00.00 UTC.
@@ -59,6 +59,5 @@ class DateParser : public ElementParser {
   int num_bytes_remaining_ = -1;
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_DATE_PARSER_H_

--- a/webm_parser/src/ebml_parser.h
+++ b/webm_parser/src/ebml_parser.h
@@ -14,7 +14,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec references:
 // http://matroska.org/technical/specs/index.html#EBML
@@ -43,6 +43,5 @@ class EbmlParser : public MasterValueParser<Ebml> {
   }
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_EBML_PARSER_H_

--- a/webm_parser/src/edition_entry_parser.h
+++ b/webm_parser/src/edition_entry_parser.h
@@ -13,7 +13,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#EditionEntry
@@ -30,6 +30,5 @@ class EditionEntryParser : public MasterValueParser<EditionEntry> {
   }
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_EDITION_ENTRY_PARSER_H_

--- a/webm_parser/src/element_parser.h
+++ b/webm_parser/src/element_parser.h
@@ -16,7 +16,7 @@
 #include "webm/callback.h"
 #include "webm/element.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Parses an element from a WebM byte stream. Objects that implement this
 // interface are expected to be used as follows in order to parse the specific
@@ -97,6 +97,5 @@ class ElementParser : public Parser {
   virtual bool WasSkipped() const { return false; }
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_ELEMENT_PARSER_H_

--- a/webm_parser/src/file_reader.cc
+++ b/webm_parser/src/file_reader.cc
@@ -29,7 +29,7 @@
   std::fseek(stream, static_cast<long>(offset), whence)
 #endif
 
-namespace webm {
+namespace adhoc::webm {
 
 FileReader::FileReader(FILE* file) : file_(file) { assert(file); }
 
@@ -139,4 +139,4 @@ Status FileReader::Seek(std::uint64_t seek_position) {
 
 std::uint64_t FileReader::Position() const { return position_; }
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/float_parser.cc
+++ b/webm_parser/src/float_parser.cc
@@ -17,7 +17,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 FloatParser::FloatParser(double default_value)
     : default_value_(default_value) {}
@@ -74,4 +74,4 @@ Status FloatParser::Feed(Callback* callback, Reader* reader,
   return status;
 }
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/float_parser.h
+++ b/webm_parser/src/float_parser.h
@@ -17,7 +17,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Parses an EBML float from a byte stream.
 class FloatParser : public ElementParser {
@@ -60,6 +60,5 @@ class FloatParser : public ElementParser {
   bool use_32_bits_;
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_FLOAT_PARSER_H_

--- a/webm_parser/src/id_element_parser.cc
+++ b/webm_parser/src/id_element_parser.cc
@@ -17,7 +17,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 Status IdElementParser::Init(const ElementMetadata& metadata,
                              std::uint64_t max_size) {
@@ -46,4 +46,4 @@ Status IdElementParser::Feed(Callback* callback, Reader* reader,
   return status;
 }
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/id_element_parser.h
+++ b/webm_parser/src/id_element_parser.h
@@ -15,7 +15,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 class IdElementParser : public ElementParser {
  public:
@@ -51,6 +51,5 @@ class IdElementParser : public ElementParser {
   int num_bytes_remaining_ = -1;
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_ID_ELEMENT_PARSER_H_

--- a/webm_parser/src/id_parser.cc
+++ b/webm_parser/src/id_parser.cc
@@ -16,7 +16,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 Status IdParser::Feed(Callback* callback, Reader* reader,
                       std::uint64_t* num_bytes_read) {
@@ -72,4 +72,4 @@ Id IdParser::id() const {
   return id_;
 }
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/id_parser.h
+++ b/webm_parser/src/id_parser.h
@@ -16,7 +16,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Parses an EBML ID from a byte stream.
 class IdParser : public Parser {
@@ -40,6 +40,5 @@ class IdParser : public Parser {
   Id id_;
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_ID_PARSER_H_

--- a/webm_parser/src/info_parser.h
+++ b/webm_parser/src/info_parser.h
@@ -16,7 +16,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#Info
@@ -39,6 +39,5 @@ class InfoParser : public MasterValueParser<Info> {
   }
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_INFO_PARSER_H_

--- a/webm_parser/src/int_parser.h
+++ b/webm_parser/src/int_parser.h
@@ -20,7 +20,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Parses an EBML signed/unsigned int from a byte stream.
 // Spec reference:
@@ -116,6 +116,5 @@ class IntParser : public ElementParser {
 using SignedIntParser = IntParser<std::int64_t>;
 using UnsignedIntParser = IntParser<std::uint64_t>;
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_INT_PARSER_H_

--- a/webm_parser/src/istream_reader.cc
+++ b/webm_parser/src/istream_reader.cc
@@ -16,7 +16,7 @@
 
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 IstreamReader::IstreamReader(IstreamReader&& other)
     : istream_(std::move(other.istream_)), position_(other.position_) {
@@ -130,4 +130,4 @@ Status IstreamReader::Skip(std::uint64_t num_to_skip,
 
 std::uint64_t IstreamReader::Position() const { return position_; }
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/master_parser.cc
+++ b/webm_parser/src/master_parser.cc
@@ -18,7 +18,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#EBML_ex
@@ -295,4 +295,4 @@ void MasterParser::PrepareForNextChild() {
   action_ = Action::kRead;
 }
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/master_parser.h
+++ b/webm_parser/src/master_parser.h
@@ -28,7 +28,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // A general purpose parser for EBML master elements.
 //
@@ -222,6 +222,5 @@ class MasterParser : public ElementParser {
   void PrepareForNextChild();
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_MASTER_PARSER_H_

--- a/webm_parser/src/master_value_parser.h
+++ b/webm_parser/src/master_value_parser.h
@@ -25,7 +25,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Parses Master elements from an EBML stream, storing child values in a
 // structure of type T. This class differs from MasterParser in that
@@ -528,6 +528,5 @@ class MasterValueParser : public ElementParser {
   }
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_MASTER_VALUE_PARSER_H_

--- a/webm_parser/src/mastering_metadata_parser.h
+++ b/webm_parser/src/mastering_metadata_parser.h
@@ -13,7 +13,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#MasteringMetadata
@@ -52,6 +52,5 @@ class MasteringMetadataParser : public MasterValueParser<MasteringMetadata> {
                                    &MasteringMetadata::luminance_min)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_MASTERING_METADATA_PARSER_H_

--- a/webm_parser/src/parser.h
+++ b/webm_parser/src/parser.h
@@ -12,7 +12,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 class Parser {
  public:
@@ -29,6 +29,5 @@ class Parser {
                       std::uint64_t* num_bytes_read) = 0;
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_PARSER_H_

--- a/webm_parser/src/parser_utils.cc
+++ b/webm_parser/src/parser_utils.cc
@@ -13,7 +13,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 Status ReadByte(Reader* reader, std::uint8_t* byte) {
   assert(reader != nullptr);
@@ -31,4 +31,4 @@ Status ReadByte(Reader* reader, std::uint8_t* byte) {
   return status;
 }
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/parser_utils.h
+++ b/webm_parser/src/parser_utils.h
@@ -15,7 +15,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Reads a single byte from the reader, and returns the status of the read. If
 // the status is not Status::kOkCompleted, then no data was read.
@@ -59,6 +59,5 @@ Status AccumulateIntegerBytes(int num_to_read, Reader* reader, T* integer,
   return Status(Status::kOkCompleted);
 }
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_PARSER_UTILS_H_

--- a/webm_parser/src/projection_parser.h
+++ b/webm_parser/src/projection_parser.h
@@ -15,7 +15,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // https://github.com/google/spatial-media/blob/master/docs/spherical-video-v2-rfc.md#projection-master-element
@@ -35,6 +35,5 @@ class ProjectionParser : public MasterValueParser<Projection> {
                                    &Projection::pose_roll)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_PROJECTION_PARSER_H_

--- a/webm_parser/src/recursive_parser.h
+++ b/webm_parser/src/recursive_parser.h
@@ -18,7 +18,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Lazily instantiates a parser of type T, and uses that parser to handle all
 // parsing operations. The parser is allocated when Init is called. This class
@@ -88,6 +88,5 @@ class RecursiveParser : public ElementParser {
   std::size_t max_recursion_depth_;
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_RECURSIVE_PARSER_H_

--- a/webm_parser/src/seek_head_parser.h
+++ b/webm_parser/src/seek_head_parser.h
@@ -12,7 +12,7 @@
 #include "src/seek_parser.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#SeekHead
@@ -22,6 +22,5 @@ class SeekHeadParser : public MasterParser {
   SeekHeadParser() : MasterParser(MakeChild<SeekParser>(Id::kSeek)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_SEEK_HEAD_PARSER_H_

--- a/webm_parser/src/seek_parser.h
+++ b/webm_parser/src/seek_parser.h
@@ -14,7 +14,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#Seek
@@ -32,6 +32,5 @@ class SeekParser : public MasterValueParser<Seek> {
   }
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_SEEK_PARSER_H_

--- a/webm_parser/src/segment_parser.cc
+++ b/webm_parser/src/segment_parser.cc
@@ -17,7 +17,7 @@
 #include "src/tracks_parser.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 SegmentParser::SegmentParser()
     : MasterParser(MakeChild<ChaptersParser>(Id::kChapters),
@@ -83,4 +83,4 @@ Status SegmentParser::Feed(Callback* callback, Reader* reader,
 
 bool SegmentParser::WasSkipped() const { return action_ == Action::kSkip; }
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/segment_parser.h
+++ b/webm_parser/src/segment_parser.h
@@ -15,7 +15,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Parses Segment elements from a WebM byte stream. This class adheres to the
 // ElementParser interface; see element_parser.h for further documentation on
@@ -48,6 +48,5 @@ class SegmentParser : public MasterParser {
   Action action_ = Action::kRead;
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_SEGMENT_PARSER_H_

--- a/webm_parser/src/simple_tag_parser.h
+++ b/webm_parser/src/simple_tag_parser.h
@@ -14,7 +14,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#SimpleTag
@@ -32,6 +32,5 @@ class SimpleTagParser : public MasterValueParser<SimpleTag> {
                                        max_recursive_depth)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_SIMPLE_TAG_PARSER_H_

--- a/webm_parser/src/size_parser.cc
+++ b/webm_parser/src/size_parser.cc
@@ -17,7 +17,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec references:
 // http://matroska.org/technical/specs/index.html#EBML_ex
@@ -53,4 +53,4 @@ std::uint64_t SizeParser::size() const {
   return uint_parser_.value();
 }
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/size_parser.h
+++ b/webm_parser/src/size_parser.h
@@ -16,7 +16,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 class SizeParser : public Parser {
  public:
@@ -38,6 +38,5 @@ class SizeParser : public Parser {
   VarIntParser uint_parser_;
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_SIZE_PARSER_H_

--- a/webm_parser/src/skip_callback.h
+++ b/webm_parser/src/skip_callback.h
@@ -13,7 +13,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // An implementation of Callback that skips all elements. Every method that
 // yields an action will yield Action::kSkip, and Reader::Skip will be called
@@ -58,6 +58,5 @@ class SkipCallback : public Callback {
   }
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_SKIP_CALLBACK_H_

--- a/webm_parser/src/skip_parser.cc
+++ b/webm_parser/src/skip_parser.cc
@@ -14,7 +14,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 Status SkipParser::Init(const ElementMetadata& metadata,
                         std::uint64_t max_size) {
@@ -56,4 +56,4 @@ Status SkipParser::Feed(Callback* callback, Reader* reader,
   return status;
 }
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/skip_parser.h
+++ b/webm_parser/src/skip_parser.h
@@ -15,7 +15,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // A simple parser that merely skips (via Reader::Skip) ahead in the stream
 // until the element has been fully skipped.
@@ -30,6 +30,5 @@ class SkipParser : public ElementParser {
   std::uint64_t num_bytes_remaining_;
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_SKIP_PARSER_H_

--- a/webm_parser/src/slices_parser.h
+++ b/webm_parser/src/slices_parser.h
@@ -13,7 +13,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#Slices
@@ -25,6 +25,5 @@ class SlicesParser : public MasterValueParser<Slices> {
             MakeChild<TimeSliceParser>(Id::kTimeSlice, &Slices::slices)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_SLICES_PARSER_H_

--- a/webm_parser/src/tag_parser.h
+++ b/webm_parser/src/tag_parser.h
@@ -14,7 +14,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#Tag
@@ -32,6 +32,5 @@ class TagParser : public MasterValueParser<Tag> {
   }
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_TAG_PARSER_H_

--- a/webm_parser/src/tags_parser.h
+++ b/webm_parser/src/tags_parser.h
@@ -12,7 +12,7 @@
 #include "src/tag_parser.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#Tags
@@ -22,6 +22,5 @@ class TagsParser : public MasterParser {
   TagsParser() : MasterParser(MakeChild<TagParser>(Id::kTag)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_TAGS_PARSER_H_

--- a/webm_parser/src/targets_parser.h
+++ b/webm_parser/src/targets_parser.h
@@ -14,7 +14,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#Targets
@@ -30,6 +30,5 @@ class TargetsParser : public MasterValueParser<Targets> {
                                          &Targets::track_uids)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_TARGETS_PARSER_H_

--- a/webm_parser/src/time_slice_parser.h
+++ b/webm_parser/src/time_slice_parser.h
@@ -13,7 +13,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#TimeSlice
@@ -25,6 +25,5 @@ class TimeSliceParser : public MasterValueParser<TimeSlice> {
             Id::kLaceNumber, &TimeSlice::lace_number)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_TIME_SLICE_PARSER_H_

--- a/webm_parser/src/track_entry_parser.h
+++ b/webm_parser/src/track_entry_parser.h
@@ -19,7 +19,7 @@
 #include "webm/dom_types.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#TrackEntry
@@ -60,6 +60,5 @@ class TrackEntryParser : public MasterValueParser<TrackEntry> {
   }
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_TRACK_ENTRY_PARSER_H_

--- a/webm_parser/src/tracks_parser.h
+++ b/webm_parser/src/tracks_parser.h
@@ -12,7 +12,7 @@
 #include "src/track_entry_parser.h"
 #include "webm/id.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#Tracks
@@ -22,6 +22,5 @@ class TracksParser : public MasterParser {
   TracksParser() : MasterParser(MakeChild<TrackEntryParser>(Id::kTrackEntry)) {}
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_TRACKS_PARSER_H_

--- a/webm_parser/src/unknown_parser.cc
+++ b/webm_parser/src/unknown_parser.cc
@@ -14,7 +14,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 Status UnknownParser::Init(const ElementMetadata& metadata,
                            std::uint64_t max_size) {
@@ -46,4 +46,4 @@ Status UnknownParser::Feed(Callback* callback, Reader* reader,
   return status;
 }
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/unknown_parser.h
+++ b/webm_parser/src/unknown_parser.h
@@ -15,7 +15,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Parses unknown elements by delegating to Callback::OnUnknownElement.
 class UnknownParser : public ElementParser {
@@ -33,6 +33,5 @@ class UnknownParser : public ElementParser {
   std::uint64_t bytes_remaining_;
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_UNKNOWN_PARSER_H_

--- a/webm_parser/src/var_int_parser.cc
+++ b/webm_parser/src/var_int_parser.cc
@@ -16,7 +16,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec references:
 // http://matroska.org/technical/specs/index.html#EBML_ex
@@ -68,4 +68,4 @@ Status VarIntParser::Feed(Callback* callback, Reader* reader,
   return Status(Status::kOkCompleted);
 }
 
-}  // namespace webm
+}  // namespace adhoc::webm

--- a/webm_parser/src/var_int_parser.h
+++ b/webm_parser/src/var_int_parser.h
@@ -16,7 +16,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 class VarIntParser : public Parser {
  public:

--- a/webm_parser/src/video_parser.h
+++ b/webm_parser/src/video_parser.h
@@ -23,7 +23,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#Video
@@ -117,6 +117,5 @@ class VideoParser : public MasterValueParser<Video> {
   }
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_VIDEO_PARSER_H_

--- a/webm_parser/src/virtual_block_parser.cc
+++ b/webm_parser/src/virtual_block_parser.cc
@@ -12,7 +12,7 @@
 
 #include "webm/element.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 Status VirtualBlockParser::Init(const ElementMetadata& metadata,
                                 std::uint64_t max_size) {

--- a/webm_parser/src/virtual_block_parser.h
+++ b/webm_parser/src/virtual_block_parser.h
@@ -19,7 +19,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Spec reference:
 // http://matroska.org/technical/specs/index.html#BlockVirtual
@@ -64,6 +64,5 @@ class VirtualBlockParser : public ElementParser {
   } state_ = State::kReadingHeader;
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_VIRTUAL_BLOCK_PARSER_H_

--- a/webm_parser/src/void_parser.cc
+++ b/webm_parser/src/void_parser.cc
@@ -16,7 +16,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 Status VoidParser::Init(const ElementMetadata& metadata,
                         std::uint64_t max_size) {

--- a/webm_parser/src/void_parser.h
+++ b/webm_parser/src/void_parser.h
@@ -15,7 +15,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Parses a Void element by delegating to Callback::OnVoid.
 // Spec reference:
@@ -36,6 +36,5 @@ class VoidParser : public ElementParser {
   std::uint64_t bytes_remaining_ = 0;
 };
 
-}  // namespace webm
-
+}  // namespace adhoc::webm
 #endif  // SRC_VOID_PARSER_H_

--- a/webm_parser/src/webm_parser.cc
+++ b/webm_parser/src/webm_parser.cc
@@ -16,7 +16,7 @@
 #include "src/unknown_parser.h"
 #include "webm/element.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Parses WebM EBML documents (i.e. level-0 WebM elements).
 class WebmParser::DocumentParser {

--- a/webm_parser/test_utils/element_parser_test.h
+++ b/webm_parser/test_utils/element_parser_test.h
@@ -19,7 +19,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Base class for unit tests that test an instance of the ElementParser
 // inteface. The template parameter T is the parser class being tested, and the
@@ -61,8 +61,8 @@ class ElementParserTest : public ParserTest<T> {
   void IncrementalParseAndVerify() override {
     TestInit(metadata_.size, Status::kOkCompleted);
 
-    webm::LimitedReader limited_reader(
-        std::unique_ptr<webm::Reader>(new BufferReader(std::move(reader_))));
+    adhoc::webm::LimitedReader limited_reader(
+        std::unique_ptr<adhoc::webm::Reader>(new BufferReader(std::move(reader_))));
 
     Status status;
     std::uint64_t num_bytes_read = 0;

--- a/webm_parser/test_utils/limited_reader.cc
+++ b/webm_parser/test_utils/limited_reader.cc
@@ -7,7 +7,7 @@
 // be found in the AUTHORS file in the root of the source tree.
 #include "test_utils/limited_reader.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 LimitedReader::LimitedReader(std::unique_ptr<Reader> impl)
     : impl_(std::move(impl)) {}

--- a/webm_parser/test_utils/limited_reader.h
+++ b/webm_parser/test_utils/limited_reader.h
@@ -18,7 +18,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // An adapter that uses an underlying reader to read data, but with added
 // limitations on how much data can be read/skipped. Its primary use is for

--- a/webm_parser/test_utils/mock_callback.h
+++ b/webm_parser/test_utils/mock_callback.h
@@ -17,7 +17,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // A simple version of Callback that can be used with Google Mock. By default,
 // the mocked methods will call through to the corresponding Callback methods.

--- a/webm_parser/test_utils/parser_test.h
+++ b/webm_parser/test_utils/parser_test.h
@@ -21,7 +21,7 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-namespace webm {
+namespace adhoc::webm {
 
 // Base class for unit tests that test an instance of the Parser inteface. The
 // template parameter T is the parser class being tested.
@@ -62,8 +62,8 @@ class ParserTest : public testing::Test {
   virtual void IncrementalParseAndVerify() {
     const std::uint64_t expected_num_bytes_read = reader_.size();
 
-    webm::LimitedReader limited_reader(
-        std::unique_ptr<webm::Reader>(new BufferReader(std::move(reader_))));
+    adhoc::webm::LimitedReader limited_reader(
+        std::unique_ptr<adhoc::webm::Reader>(new BufferReader(std::move(reader_))));
 
     Status status;
     std::uint64_t num_bytes_read = 0;

--- a/webm_parser/tests/audio_parser_test.cc
+++ b/webm_parser/tests/audio_parser_test.cc
@@ -12,10 +12,10 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::Audio;
-using webm::AudioParser;
-using webm::ElementParserTest;
-using webm::Id;
+using adhoc::webm::Audio;
+using adhoc::webm::AudioParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
 
 namespace {
 

--- a/webm_parser/tests/bit_utils_test.cc
+++ b/webm_parser/tests/bit_utils_test.cc
@@ -9,7 +9,7 @@
 
 #include "gtest/gtest.h"
 
-using webm::CountLeadingZeros;
+using adhoc::webm::CountLeadingZeros;
 
 namespace {
 

--- a/webm_parser/tests/block_additions_parser_test.cc
+++ b/webm_parser/tests/block_additions_parser_test.cc
@@ -12,11 +12,11 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::BlockAdditions;
-using webm::BlockAdditionsParser;
-using webm::BlockMore;
-using webm::ElementParserTest;
-using webm::Id;
+using adhoc::webm::BlockAdditions;
+using adhoc::webm::BlockAdditionsParser;
+using adhoc::webm::BlockMore;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
 
 namespace {
 

--- a/webm_parser/tests/block_group_parser_test.cc
+++ b/webm_parser/tests/block_group_parser_test.cc
@@ -19,17 +19,17 @@ using testing::InSequence;
 using testing::NotNull;
 using testing::Return;
 
-using webm::Block;
-using webm::BlockAdditions;
-using webm::BlockGroup;
-using webm::BlockGroupParser;
-using webm::BlockMore;
-using webm::ElementParserTest;
-using webm::Id;
-using webm::Slices;
-using webm::Status;
-using webm::TimeSlice;
-using webm::VirtualBlock;
+using adhoc::webm::Block;
+using adhoc::webm::BlockAdditions;
+using adhoc::webm::BlockGroup;
+using adhoc::webm::BlockGroupParser;
+using adhoc::webm::BlockMore;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::Slices;
+using adhoc::webm::Status;
+using adhoc::webm::TimeSlice;
+using adhoc::webm::VirtualBlock;
 
 namespace {
 

--- a/webm_parser/tests/block_header_parser_test.cc
+++ b/webm_parser/tests/block_header_parser_test.cc
@@ -12,9 +12,9 @@
 #include "test_utils/parser_test.h"
 #include "webm/status.h"
 
-using webm::BlockHeader;
-using webm::BlockHeaderParser;
-using webm::ParserTest;
+using adhoc::webm::BlockHeader;
+using adhoc::webm::BlockHeaderParser;
+using adhoc::webm::ParserTest;
 
 namespace {
 

--- a/webm_parser/tests/block_more_parser_test.cc
+++ b/webm_parser/tests/block_more_parser_test.cc
@@ -12,10 +12,10 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::BlockMore;
-using webm::BlockMoreParser;
-using webm::ElementParserTest;
-using webm::Id;
+using adhoc::webm::BlockMore;
+using adhoc::webm::BlockMoreParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
 
 namespace {
 

--- a/webm_parser/tests/block_parser_test.cc
+++ b/webm_parser/tests/block_parser_test.cc
@@ -30,19 +30,19 @@ using testing::NotNull;
 using testing::Return;
 using testing::SetArgPointee;
 
-using webm::Action;
-using webm::Block;
-using webm::BlockParser;
-using webm::ElementParserTest;
-using webm::FrameMetadata;
-using webm::Id;
-using webm::kUnknownElementSize;
-using webm::Lacing;
-using webm::ReadByte;
-using webm::Reader;
-using webm::SimpleBlock;
-using webm::SimpleBlockParser;
-using webm::Status;
+using adhoc::webm::Action;
+using adhoc::webm::Block;
+using adhoc::webm::BlockParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::FrameMetadata;
+using adhoc::webm::Id;
+using adhoc::webm::kUnknownElementSize;
+using adhoc::webm::Lacing;
+using adhoc::webm::ReadByte;
+using adhoc::webm::Reader;
+using adhoc::webm::SimpleBlock;
+using adhoc::webm::SimpleBlockParser;
+using adhoc::webm::Status;
 
 namespace {
 

--- a/webm_parser/tests/bool_parser_test.cc
+++ b/webm_parser/tests/bool_parser_test.cc
@@ -12,10 +12,10 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/status.h"
 
-using webm::BoolParser;
-using webm::ElementParserTest;
-using webm::kUnknownElementSize;
-using webm::Status;
+using adhoc::webm::BoolParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::kUnknownElementSize;
+using adhoc::webm::Status;
 
 namespace {
 

--- a/webm_parser/tests/buffer_reader_test.cc
+++ b/webm_parser/tests/buffer_reader_test.cc
@@ -12,8 +12,8 @@
 
 #include "gtest/gtest.h"
 
-using webm::BufferReader;
-using webm::Status;
+using adhoc::webm::BufferReader;
+using adhoc::webm::Status;
 
 namespace {
 

--- a/webm_parser/tests/byte_parser_test.cc
+++ b/webm_parser/tests/byte_parser_test.cc
@@ -12,11 +12,11 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/status.h"
 
-using webm::BinaryParser;
-using webm::ElementParserTest;
-using webm::kUnknownElementSize;
-using webm::Status;
-using webm::StringParser;
+using adhoc::webm::BinaryParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::kUnknownElementSize;
+using adhoc::webm::Status;
+using adhoc::webm::StringParser;
 
 namespace {
 

--- a/webm_parser/tests/callback_test.cc
+++ b/webm_parser/tests/callback_test.cc
@@ -15,12 +15,12 @@
 #include "webm/element.h"
 #include "webm/status.h"
 
-using webm::Action;
-using webm::BufferReader;
-using webm::Callback;
-using webm::ElementMetadata;
-using webm::Reader;
-using webm::Status;
+using adhoc::webm::Action;
+using adhoc::webm::BufferReader;
+using adhoc::webm::Callback;
+using adhoc::webm::ElementMetadata;
+using adhoc::webm::Reader;
+using adhoc::webm::Status;
 
 namespace {
 

--- a/webm_parser/tests/chapter_atom_parser_test.cc
+++ b/webm_parser/tests/chapter_atom_parser_test.cc
@@ -13,12 +13,12 @@
 #include "webm/id.h"
 #include "webm/status.h"
 
-using webm::ChapterAtom;
-using webm::ChapterAtomParser;
-using webm::ChapterDisplay;
-using webm::ElementParserTest;
-using webm::Id;
-using webm::Status;
+using adhoc::webm::ChapterAtom;
+using adhoc::webm::ChapterAtomParser;
+using adhoc::webm::ChapterDisplay;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::Status;
 
 namespace {
 

--- a/webm_parser/tests/chapter_display_parser_test.cc
+++ b/webm_parser/tests/chapter_display_parser_test.cc
@@ -12,10 +12,10 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::ChapterDisplay;
-using webm::ChapterDisplayParser;
-using webm::ElementParserTest;
-using webm::Id;
+using adhoc::webm::ChapterDisplay;
+using adhoc::webm::ChapterDisplayParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
 
 namespace {
 

--- a/webm_parser/tests/chapters_parser_test.cc
+++ b/webm_parser/tests/chapters_parser_test.cc
@@ -12,9 +12,9 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::ChaptersParser;
-using webm::ElementParserTest;
-using webm::Id;
+using adhoc::webm::ChaptersParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
 
 namespace {
 

--- a/webm_parser/tests/cluster_parser_test.cc
+++ b/webm_parser/tests/cluster_parser_test.cc
@@ -21,16 +21,16 @@ using testing::NotNull;
 using testing::Return;
 using testing::SetArgPointee;
 
-using webm::Action;
-using webm::Ancestory;
-using webm::BlockGroup;
-using webm::Cluster;
-using webm::ClusterParser;
-using webm::ElementMetadata;
-using webm::ElementParserTest;
-using webm::Id;
-using webm::SimpleBlock;
-using webm::Status;
+using adhoc::webm::Action;
+using adhoc::webm::Ancestory;
+using adhoc::webm::BlockGroup;
+using adhoc::webm::Cluster;
+using adhoc::webm::ClusterParser;
+using adhoc::webm::ElementMetadata;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::SimpleBlock;
+using adhoc::webm::Status;
 
 namespace {
 

--- a/webm_parser/tests/colour_parser_test.cc
+++ b/webm_parser/tests/colour_parser_test.cc
@@ -12,15 +12,15 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::Colour;
-using webm::ColourParser;
-using webm::ElementParserTest;
-using webm::Id;
-using webm::MasteringMetadata;
-using webm::MatrixCoefficients;
-using webm::Primaries;
-using webm::Range;
-using webm::TransferCharacteristics;
+using adhoc::webm::Colour;
+using adhoc::webm::ColourParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::MasteringMetadata;
+using adhoc::webm::MatrixCoefficients;
+using adhoc::webm::Primaries;
+using adhoc::webm::Range;
+using adhoc::webm::TransferCharacteristics;
 
 namespace {
 

--- a/webm_parser/tests/content_enc_aes_settings_parser_test.cc
+++ b/webm_parser/tests/content_enc_aes_settings_parser_test.cc
@@ -12,11 +12,11 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::AesSettingsCipherMode;
-using webm::ContentEncAesSettings;
-using webm::ContentEncAesSettingsParser;
-using webm::ElementParserTest;
-using webm::Id;
+using adhoc::webm::AesSettingsCipherMode;
+using adhoc::webm::ContentEncAesSettings;
+using adhoc::webm::ContentEncAesSettingsParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
 
 namespace {
 

--- a/webm_parser/tests/content_encoding_parser_test.cc
+++ b/webm_parser/tests/content_encoding_parser_test.cc
@@ -12,13 +12,13 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::ContentEncAlgo;
-using webm::ContentEncoding;
-using webm::ContentEncodingParser;
-using webm::ContentEncodingType;
-using webm::ContentEncryption;
-using webm::ElementParserTest;
-using webm::Id;
+using adhoc::webm::ContentEncAlgo;
+using adhoc::webm::ContentEncoding;
+using adhoc::webm::ContentEncodingParser;
+using adhoc::webm::ContentEncodingType;
+using adhoc::webm::ContentEncryption;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
 
 namespace {
 

--- a/webm_parser/tests/content_encodings_parser_test.cc
+++ b/webm_parser/tests/content_encodings_parser_test.cc
@@ -12,11 +12,11 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::ContentEncoding;
-using webm::ContentEncodings;
-using webm::ContentEncodingsParser;
-using webm::ElementParserTest;
-using webm::Id;
+using adhoc::webm::ContentEncoding;
+using adhoc::webm::ContentEncodings;
+using adhoc::webm::ContentEncodingsParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
 
 namespace {
 

--- a/webm_parser/tests/content_encryption_parser_test.cc
+++ b/webm_parser/tests/content_encryption_parser_test.cc
@@ -14,13 +14,13 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::AesSettingsCipherMode;
-using webm::ContentEncAesSettings;
-using webm::ContentEncAlgo;
-using webm::ContentEncryption;
-using webm::ContentEncryptionParser;
-using webm::ElementParserTest;
-using webm::Id;
+using adhoc::webm::AesSettingsCipherMode;
+using adhoc::webm::ContentEncAesSettings;
+using adhoc::webm::ContentEncAlgo;
+using adhoc::webm::ContentEncryption;
+using adhoc::webm::ContentEncryptionParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
 
 namespace {
 

--- a/webm_parser/tests/cue_point_parser_test.cc
+++ b/webm_parser/tests/cue_point_parser_test.cc
@@ -13,11 +13,11 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::CuePoint;
-using webm::CuePointParser;
-using webm::CueTrackPositions;
-using webm::ElementParserTest;
-using webm::Id;
+using adhoc::webm::CuePoint;
+using adhoc::webm::CuePointParser;
+using adhoc::webm::CueTrackPositions;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
 
 namespace {
 

--- a/webm_parser/tests/cue_track_positions_parser_test.cc
+++ b/webm_parser/tests/cue_track_positions_parser_test.cc
@@ -12,10 +12,10 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::CueTrackPositions;
-using webm::CueTrackPositionsParser;
-using webm::ElementParserTest;
-using webm::Id;
+using adhoc::webm::CueTrackPositions;
+using adhoc::webm::CueTrackPositionsParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
 
 namespace {
 

--- a/webm_parser/tests/cues_parser_test.cc
+++ b/webm_parser/tests/cues_parser_test.cc
@@ -12,9 +12,9 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::CuesParser;
-using webm::ElementParserTest;
-using webm::Id;
+using adhoc::webm::CuesParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
 
 namespace {
 

--- a/webm_parser/tests/date_parser_test.cc
+++ b/webm_parser/tests/date_parser_test.cc
@@ -12,10 +12,10 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/status.h"
 
-using webm::DateParser;
-using webm::ElementParserTest;
-using webm::kUnknownElementSize;
-using webm::Status;
+using adhoc::webm::DateParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::kUnknownElementSize;
+using adhoc::webm::Status;
 
 namespace {
 

--- a/webm_parser/tests/ebml_parser_test.cc
+++ b/webm_parser/tests/ebml_parser_test.cc
@@ -13,10 +13,10 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::Ebml;
-using webm::EbmlParser;
-using webm::ElementParserTest;
-using webm::Id;
+using adhoc::webm::Ebml;
+using adhoc::webm::EbmlParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
 
 namespace {
 

--- a/webm_parser/tests/edition_entry_parser_test.cc
+++ b/webm_parser/tests/edition_entry_parser_test.cc
@@ -13,11 +13,11 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::ChapterAtom;
-using webm::EditionEntry;
-using webm::EditionEntryParser;
-using webm::ElementParserTest;
-using webm::Id;
+using adhoc::webm::ChapterAtom;
+using adhoc::webm::EditionEntry;
+using adhoc::webm::EditionEntryParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
 
 namespace {
 

--- a/webm_parser/tests/element_test.cc
+++ b/webm_parser/tests/element_test.cc
@@ -12,7 +12,7 @@
 
 #include "gtest/gtest.h"
 
-using webm::Element;
+using adhoc::webm::Element;
 
 namespace {
 

--- a/webm_parser/tests/float_parser_test.cc
+++ b/webm_parser/tests/float_parser_test.cc
@@ -12,10 +12,10 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/status.h"
 
-using webm::ElementParserTest;
-using webm::FloatParser;
-using webm::kUnknownElementSize;
-using webm::Status;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::FloatParser;
+using adhoc::webm::kUnknownElementSize;
+using adhoc::webm::Status;
 
 namespace {
 

--- a/webm_parser/tests/id_element_parser_test.cc
+++ b/webm_parser/tests/id_element_parser_test.cc
@@ -14,11 +14,11 @@
 #include "webm/id.h"
 #include "webm/status.h"
 
-using webm::ElementParserTest;
-using webm::Id;
-using webm::IdElementParser;
-using webm::kUnknownElementSize;
-using webm::Status;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::IdElementParser;
+using adhoc::webm::kUnknownElementSize;
+using adhoc::webm::Status;
 
 namespace {
 

--- a/webm_parser/tests/id_parser_test.cc
+++ b/webm_parser/tests/id_parser_test.cc
@@ -13,10 +13,10 @@
 #include "webm/id.h"
 #include "webm/status.h"
 
-using webm::Id;
-using webm::IdParser;
-using webm::ParserTest;
-using webm::Status;
+using adhoc::webm::Id;
+using adhoc::webm::IdParser;
+using adhoc::webm::ParserTest;
+using adhoc::webm::Status;
 
 namespace {
 

--- a/webm_parser/tests/info_parser_test.cc
+++ b/webm_parser/tests/info_parser_test.cc
@@ -13,10 +13,10 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::ElementParserTest;
-using webm::Id;
-using webm::Info;
-using webm::InfoParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::Info;
+using adhoc::webm::InfoParser;
 
 namespace {
 

--- a/webm_parser/tests/int_parser_test.cc
+++ b/webm_parser/tests/int_parser_test.cc
@@ -12,11 +12,11 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/status.h"
 
-using webm::ElementParserTest;
-using webm::kUnknownElementSize;
-using webm::SignedIntParser;
-using webm::Status;
-using webm::UnsignedIntParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::kUnknownElementSize;
+using adhoc::webm::SignedIntParser;
+using adhoc::webm::Status;
+using adhoc::webm::UnsignedIntParser;
 
 namespace {
 

--- a/webm_parser/tests/istream_reader_test.cc
+++ b/webm_parser/tests/istream_reader_test.cc
@@ -15,8 +15,8 @@
 
 #include "gtest/gtest.h"
 
-using webm::IstreamReader;
-using webm::Status;
+using adhoc::webm::IstreamReader;
+using adhoc::webm::Status;
 
 namespace {
 

--- a/webm_parser/tests/limited_reader_test.cc
+++ b/webm_parser/tests/limited_reader_test.cc
@@ -17,10 +17,10 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-using webm::BufferReader;
-using webm::LimitedReader;
-using webm::Reader;
-using webm::Status;
+using adhoc::webm::BufferReader;
+using adhoc::webm::LimitedReader;
+using adhoc::webm::Reader;
+using adhoc::webm::Status;
 
 namespace {
 

--- a/webm_parser/tests/master_parser_test.cc
+++ b/webm_parser/tests/master_parser_test.cc
@@ -27,16 +27,16 @@ using testing::NotNull;
 using testing::Return;
 using testing::SetArgPointee;
 
-using webm::Action;
-using webm::BinaryParser;
-using webm::ElementMetadata;
-using webm::ElementParser;
-using webm::ElementParserTest;
-using webm::Id;
-using webm::kUnknownElementSize;
-using webm::LimitedReader;
-using webm::MasterParser;
-using webm::Status;
+using adhoc::webm::Action;
+using adhoc::webm::BinaryParser;
+using adhoc::webm::ElementMetadata;
+using adhoc::webm::ElementParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::kUnknownElementSize;
+using adhoc::webm::LimitedReader;
+using adhoc::webm::MasterParser;
+using adhoc::webm::Status;
 
 namespace {
 

--- a/webm_parser/tests/master_value_parser_test.cc
+++ b/webm_parser/tests/master_value_parser_test.cc
@@ -23,15 +23,15 @@ using testing::NotNull;
 using testing::Return;
 using testing::SetArgPointee;
 
-using webm::Action;
-using webm::Callback;
-using webm::Cluster;
-using webm::ElementMetadata;
-using webm::ElementParserTest;
-using webm::Id;
-using webm::MasterValueParser;
-using webm::Status;
-using webm::UnsignedIntParser;
+using adhoc::webm::Action;
+using adhoc::webm::Callback;
+using adhoc::webm::Cluster;
+using adhoc::webm::ElementMetadata;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::MasterValueParser;
+using adhoc::webm::Status;
+using adhoc::webm::UnsignedIntParser;
 
 namespace {
 

--- a/webm_parser/tests/mastering_metadata_parser_test.cc
+++ b/webm_parser/tests/mastering_metadata_parser_test.cc
@@ -12,10 +12,10 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::ElementParserTest;
-using webm::Id;
-using webm::MasteringMetadata;
-using webm::MasteringMetadataParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::MasteringMetadata;
+using adhoc::webm::MasteringMetadataParser;
 
 namespace {
 

--- a/webm_parser/tests/parser_utils_test.cc
+++ b/webm_parser/tests/parser_utils_test.cc
@@ -18,10 +18,10 @@
 #include "webm/reader.h"
 #include "webm/status.h"
 
-using webm::BufferReader;
-using webm::LimitedReader;
-using webm::Reader;
-using webm::Status;
+using adhoc::webm::BufferReader;
+using adhoc::webm::LimitedReader;
+using adhoc::webm::Reader;
+using adhoc::webm::Status;
 
 namespace {
 

--- a/webm_parser/tests/projection_parser_test.cc
+++ b/webm_parser/tests/projection_parser_test.cc
@@ -12,11 +12,11 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::ElementParserTest;
-using webm::Id;
-using webm::Projection;
-using webm::ProjectionParser;
-using webm::ProjectionType;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::Projection;
+using adhoc::webm::ProjectionParser;
+using adhoc::webm::ProjectionType;
 
 namespace {
 

--- a/webm_parser/tests/recursive_parser_test.cc
+++ b/webm_parser/tests/recursive_parser_test.cc
@@ -17,14 +17,14 @@
 #include "webm/element.h"
 #include "webm/status.h"
 
-using webm::Callback;
-using webm::ElementMetadata;
-using webm::ElementParser;
-using webm::ElementParserTest;
-using webm::Reader;
-using webm::RecursiveParser;
-using webm::Status;
-using webm::StringParser;
+using adhoc::webm::Callback;
+using adhoc::webm::ElementMetadata;
+using adhoc::webm::ElementParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Reader;
+using adhoc::webm::RecursiveParser;
+using adhoc::webm::Status;
+using adhoc::webm::StringParser;
 
 namespace {
 

--- a/webm_parser/tests/seek_head_parser_test.cc
+++ b/webm_parser/tests/seek_head_parser_test.cc
@@ -12,9 +12,9 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/buffer_reader.h"
 
-using webm::ElementParserTest;
-using webm::Id;
-using webm::SeekHeadParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::SeekHeadParser;
 
 namespace {
 

--- a/webm_parser/tests/seek_parser_test.cc
+++ b/webm_parser/tests/seek_parser_test.cc
@@ -13,10 +13,10 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::ElementParserTest;
-using webm::Id;
-using webm::Seek;
-using webm::SeekParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::Seek;
+using adhoc::webm::SeekParser;
 
 namespace {
 

--- a/webm_parser/tests/segment_parser_test.cc
+++ b/webm_parser/tests/segment_parser_test.cc
@@ -23,13 +23,13 @@ using testing::NotNull;
 using testing::Return;
 using testing::SetArgPointee;
 
-using webm::Action;
-using webm::Ancestory;
-using webm::ElementMetadata;
-using webm::ElementParserTest;
-using webm::Id;
-using webm::SegmentParser;
-using webm::Status;
+using adhoc::webm::Action;
+using adhoc::webm::Ancestory;
+using adhoc::webm::ElementMetadata;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::SegmentParser;
+using adhoc::webm::Status;
 
 namespace {
 

--- a/webm_parser/tests/simple_tag_parser_test.cc
+++ b/webm_parser/tests/simple_tag_parser_test.cc
@@ -15,11 +15,11 @@
 #include "webm/id.h"
 #include "webm/status.h"
 
-using webm::ElementParserTest;
-using webm::Id;
-using webm::SimpleTag;
-using webm::SimpleTagParser;
-using webm::Status;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::SimpleTag;
+using adhoc::webm::SimpleTagParser;
+using adhoc::webm::Status;
 
 namespace {
 

--- a/webm_parser/tests/size_parser_test.cc
+++ b/webm_parser/tests/size_parser_test.cc
@@ -12,9 +12,9 @@
 #include "test_utils/parser_test.h"
 #include "webm/status.h"
 
-using webm::ParserTest;
-using webm::SizeParser;
-using webm::Status;
+using adhoc::webm::ParserTest;
+using adhoc::webm::SizeParser;
+using adhoc::webm::Status;
 
 namespace {
 

--- a/webm_parser/tests/skip_parser_test.cc
+++ b/webm_parser/tests/skip_parser_test.cc
@@ -13,10 +13,10 @@
 #include "webm/element.h"
 #include "webm/status.h"
 
-using webm::ElementParserTest;
-using webm::kUnknownElementSize;
-using webm::SkipParser;
-using webm::Status;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::kUnknownElementSize;
+using adhoc::webm::SkipParser;
+using adhoc::webm::Status;
 
 namespace {
 

--- a/webm_parser/tests/slices_parser_test.cc
+++ b/webm_parser/tests/slices_parser_test.cc
@@ -12,11 +12,11 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::ElementParserTest;
-using webm::Id;
-using webm::Slices;
-using webm::SlicesParser;
-using webm::TimeSlice;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::Slices;
+using adhoc::webm::SlicesParser;
+using adhoc::webm::TimeSlice;
 
 namespace {
 

--- a/webm_parser/tests/tag_parser_test.cc
+++ b/webm_parser/tests/tag_parser_test.cc
@@ -13,12 +13,12 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::ElementParserTest;
-using webm::Id;
-using webm::SimpleTag;
-using webm::Tag;
-using webm::TagParser;
-using webm::Targets;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::SimpleTag;
+using adhoc::webm::Tag;
+using adhoc::webm::TagParser;
+using adhoc::webm::Targets;
 
 namespace {
 

--- a/webm_parser/tests/tags_parser_test.cc
+++ b/webm_parser/tests/tags_parser_test.cc
@@ -12,9 +12,9 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/buffer_reader.h"
 
-using webm::ElementParserTest;
-using webm::Id;
-using webm::TagsParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::TagsParser;
 
 namespace {
 

--- a/webm_parser/tests/targets_parser_test.cc
+++ b/webm_parser/tests/targets_parser_test.cc
@@ -12,10 +12,10 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::ElementParserTest;
-using webm::Id;
-using webm::Targets;
-using webm::TargetsParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::Targets;
+using adhoc::webm::TargetsParser;
 
 namespace {
 

--- a/webm_parser/tests/time_slice_parser_test.cc
+++ b/webm_parser/tests/time_slice_parser_test.cc
@@ -12,10 +12,10 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::ElementParserTest;
-using webm::Id;
-using webm::TimeSlice;
-using webm::TimeSliceParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::TimeSlice;
+using adhoc::webm::TimeSliceParser;
 
 namespace {
 

--- a/webm_parser/tests/track_entry_parser_test.cc
+++ b/webm_parser/tests/track_entry_parser_test.cc
@@ -15,16 +15,16 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::Audio;
-using webm::ContentEncoding;
-using webm::ContentEncodings;
-using webm::DisplayUnit;
-using webm::ElementParserTest;
-using webm::Id;
-using webm::TrackEntry;
-using webm::TrackEntryParser;
-using webm::TrackType;
-using webm::Video;
+using adhoc::webm::Audio;
+using adhoc::webm::ContentEncoding;
+using adhoc::webm::ContentEncodings;
+using adhoc::webm::DisplayUnit;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::TrackEntry;
+using adhoc::webm::TrackEntryParser;
+using adhoc::webm::TrackType;
+using adhoc::webm::Video;
 
 namespace {
 

--- a/webm_parser/tests/tracks_parser_test.cc
+++ b/webm_parser/tests/tracks_parser_test.cc
@@ -12,9 +12,9 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/buffer_reader.h"
 
-using webm::ElementParserTest;
-using webm::Id;
-using webm::TracksParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::TracksParser;
 
 namespace {
 

--- a/webm_parser/tests/unknown_parser_test.cc
+++ b/webm_parser/tests/unknown_parser_test.cc
@@ -16,10 +16,10 @@
 
 using testing::NotNull;
 
-using webm::ElementParserTest;
-using webm::kUnknownElementSize;
-using webm::Status;
-using webm::UnknownParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::kUnknownElementSize;
+using adhoc::webm::Status;
+using adhoc::webm::UnknownParser;
 
 namespace {
 

--- a/webm_parser/tests/var_int_parser_test.cc
+++ b/webm_parser/tests/var_int_parser_test.cc
@@ -12,9 +12,9 @@
 #include "test_utils/parser_test.h"
 #include "webm/status.h"
 
-using webm::ParserTest;
-using webm::Status;
-using webm::VarIntParser;
+using adhoc::webm::ParserTest;
+using adhoc::webm::Status;
+using adhoc::webm::VarIntParser;
 
 namespace {
 

--- a/webm_parser/tests/video_parser_test.cc
+++ b/webm_parser/tests/video_parser_test.cc
@@ -12,17 +12,17 @@
 #include "test_utils/element_parser_test.h"
 #include "webm/id.h"
 
-using webm::AspectRatioType;
-using webm::Colour;
-using webm::DisplayUnit;
-using webm::ElementParserTest;
-using webm::FlagInterlaced;
-using webm::Id;
-using webm::Projection;
-using webm::ProjectionType;
-using webm::StereoMode;
-using webm::Video;
-using webm::VideoParser;
+using adhoc::webm::AspectRatioType;
+using adhoc::webm::Colour;
+using adhoc::webm::DisplayUnit;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::FlagInterlaced;
+using adhoc::webm::Id;
+using adhoc::webm::Projection;
+using adhoc::webm::ProjectionType;
+using adhoc::webm::StereoMode;
+using adhoc::webm::Video;
+using adhoc::webm::VideoParser;
 
 namespace {
 

--- a/webm_parser/tests/virtual_block_parser_test.cc
+++ b/webm_parser/tests/virtual_block_parser_test.cc
@@ -13,12 +13,12 @@
 #include "webm/id.h"
 #include "webm/status.h"
 
-using webm::ElementParserTest;
-using webm::Id;
-using webm::kUnknownElementSize;
-using webm::Status;
-using webm::VirtualBlock;
-using webm::VirtualBlockParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::kUnknownElementSize;
+using adhoc::webm::Status;
+using adhoc::webm::VirtualBlock;
+using adhoc::webm::VirtualBlockParser;
 
 namespace {
 

--- a/webm_parser/tests/void_parser_test.cc
+++ b/webm_parser/tests/void_parser_test.cc
@@ -17,11 +17,11 @@
 
 using testing::NotNull;
 
-using webm::ElementParserTest;
-using webm::Id;
-using webm::kUnknownElementSize;
-using webm::Status;
-using webm::VoidParser;
+using adhoc::webm::ElementParserTest;
+using adhoc::webm::Id;
+using adhoc::webm::kUnknownElementSize;
+using adhoc::webm::Status;
+using adhoc::webm::VoidParser;
 
 namespace {
 

--- a/webm_parser/tests/webm_parser_test.cc
+++ b/webm_parser/tests/webm_parser_test.cc
@@ -20,17 +20,17 @@ using testing::InSequence;
 using testing::NotNull;
 using testing::Return;
 
-using webm::BufferReader;
-using webm::Ebml;
-using webm::ElementMetadata;
-using webm::Id;
-using webm::Info;
-using webm::kUnknownElementPosition;
-using webm::kUnknownElementSize;
-using webm::kUnknownHeaderSize;
-using webm::MockCallback;
-using webm::Status;
-using webm::WebmParser;
+using adhoc::webm::BufferReader;
+using adhoc::webm::Ebml;
+using adhoc::webm::ElementMetadata;
+using adhoc::webm::Id;
+using adhoc::webm::Info;
+using adhoc::webm::kUnknownElementPosition;
+using adhoc::webm::kUnknownElementSize;
+using adhoc::webm::kUnknownHeaderSize;
+using adhoc::webm::MockCallback;
+using adhoc::webm::Status;
+using adhoc::webm::WebmParser;
 
 namespace {
 

--- a/webmids.hpp
+++ b/webmids.hpp
@@ -12,12 +12,12 @@
 // New projects should not include this file: include the file included below.
 #include "common/webmids.h"
 
-namespace mkvmuxer {
+namespace adhoc::mkvmuxer {
 // MkvId moved from the mkvmuxer namespace to the libwebm namespace. Pull all
 // of libwebm into mkvmuxer to ease transition to the new namespace. New
-// projects should use libwebm::MkvId and should not expect to find MkvId in
+// projects should use adhoc::libwebm::MkvId and should not expect to find MkvId in
 // mkvmuxer.
 using namespace libwebm;
-}  // namespace mkvmuxer
+}  // namespace adhoc::mkvmuxer
 
 #endif  // LIBWEBM_WEBMIDS_HPP_

--- a/webvtt/vttreader.cc
+++ b/webvtt/vttreader.cc
@@ -8,7 +8,7 @@
 
 #include "webvtt/vttreader.h"
 
-namespace libwebvtt {
+namespace adhoc::libwebvtt {
 
 VttReader::VttReader() : file_(NULL) {}
 

--- a/webvtt/vttreader.h
+++ b/webvtt/vttreader.h
@@ -12,9 +12,9 @@
 #include <cstdio>
 #include "./webvttparser.h"
 
-namespace libwebvtt {
+namespace adhoc::libwebvtt {
 
-class VttReader : public libwebvtt::Reader {
+class VttReader : public adhoc::libwebvtt::Reader {
  public:
   VttReader();
   virtual ~VttReader();

--- a/webvtt/webvttparser.cc
+++ b/webvtt/webvttparser.cc
@@ -13,7 +13,7 @@
 #include <climits>
 #include <cstddef>
 
-namespace libwebvtt {
+namespace adhoc::libwebvtt {
 
 // NOLINT'ing this enum because clang-format puts it in a single line which
 // makes it look really unreadable.

--- a/webvtt/webvttparser.h
+++ b/webvtt/webvttparser.h
@@ -12,7 +12,7 @@
 #include <list>
 #include <string>
 
-namespace libwebvtt {
+namespace adhoc::libwebvtt {
 
 class Reader {
  public:


### PR DESCRIPTION
Some of these aren't strictly necessary (e.g. test), but for consistency, I did all of them. This was done to avoid name conflicts on Switch due to there being an old version of libwebm that is already compiled into one of their core libraries that gets pulled in.